### PR TITLE
fix: fibonacci example

### DIFF
--- a/crates/core/executor/src/syscalls/hint.rs
+++ b/crates/core/executor/src/syscalls/hint.rs
@@ -59,7 +59,7 @@ impl Syscall for HintReadSyscall {
             let b2 = vec.get(i as usize + 1).copied().unwrap_or(0);
             let b3 = vec.get(i as usize + 2).copied().unwrap_or(0);
             let b4 = vec.get(i as usize + 3).copied().unwrap_or(0);
-            let word = u32::from_be_bytes([b1, b2, b3, b4]);
+            let word = u32::from_le_bytes([b1, b2, b3, b4]);
 
             // Save the data into runtime state so the runtime will use the desired data instead of
             // 0 when first reading/writing from this address.

--- a/crates/core/executor/src/syscalls/hint.rs
+++ b/crates/core/executor/src/syscalls/hint.rs
@@ -59,7 +59,7 @@ impl Syscall for HintReadSyscall {
             let b2 = vec.get(i as usize + 1).copied().unwrap_or(0);
             let b3 = vec.get(i as usize + 2).copied().unwrap_or(0);
             let b4 = vec.get(i as usize + 3).copied().unwrap_or(0);
-            let word = u32::from_le_bytes([b1, b2, b3, b4]);
+            let word = u32::from_be_bytes([b1, b2, b3, b4]);
 
             // Save the data into runtime state so the runtime will use the desired data instead of
             // 0 when first reading/writing from this address.

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -295,7 +295,7 @@ impl ProverClient {
         ZKM_CIRCUIT_VERSION.to_string()
     }
 
-    /// Setup a program to be proven and verified by the ZKM RISC-V zkVM by computing the proving
+    /// Setup a program to be proven and verified by the ZKM MIPS zkVM by computing the proving
     /// and verifying keys.
     ///
     /// The proving key and verifying key essentially embed the program, as well as other auxiliary

--- a/crates/sdk/src/provers/mod.rs
+++ b/crates/sdk/src/provers/mod.rs
@@ -72,7 +72,7 @@ pub trait Prover<C: ZKMProverComponents>: Send + Sync {
 
     fn setup(&self, elf: &[u8]) -> (ZKMProvingKey, ZKMVerifyingKey);
 
-    /// Prove the execution of a RISCV ELF with the given inputs, according to the given proof mode.
+    /// Prove the execution of a MIPS ELF with the given inputs, according to the given proof mode.
     fn prove<'a>(
         &'a self,
         pk: &ZKMProvingKey,

--- a/crates/zkvm/entrypoint/src/lib.rs
+++ b/crates/zkvm/entrypoint/src/lib.rs
@@ -1,4 +1,4 @@
-//! Ported from Entrypoint for SP1 zkVM.
+//! Ported from Entrypoint for ZKM2 zkVM.
 #![feature(asm_experimental_arch)]
 pub mod heap;
 pub mod syscalls;

--- a/examples/fibonacci/script/bin/compressed.rs
+++ b/examples/fibonacci/script/bin/compressed.rs
@@ -1,4 +1,4 @@
-use zkm2_sdk::{include_elf, utils, ProverClient, SP1Stdin};
+use zkm2_sdk::{include_elf, utils, ProverClient, ZKMStdin};
 
 /// The ELF we want to execute inside the zkVM.
 const ELF: &[u8] = include_elf!("fibonacci-program");
@@ -9,7 +9,7 @@ fn main() {
 
     // Create an input stream and write '500' to it.
     let n = 500u32;
-    let mut stdin = SP1Stdin::new();
+    let mut stdin = ZKMStdin::new();
     stdin.write(&n);
 
     // Generate the constant-sized proof for the given program and input.

--- a/examples/fibonacci/script/bin/execute.rs
+++ b/examples/fibonacci/script/bin/execute.rs
@@ -18,7 +18,7 @@ fn main() {
     let (mut public_values, execution_report) = client.execute(ELF, stdin).run().unwrap();
 
     // Print the total number of cycles executed and the full execution report with a breakdown of
-    // the RISC-V opcode and syscall counts.
+    // the MIPS opcode and syscall counts.
     println!(
         "Executed program with {} cycles",
         execution_report.total_instruction_count() + execution_report.total_syscall_count()

--- a/examples/fibonacci/script/bin/execute.rs
+++ b/examples/fibonacci/script/bin/execute.rs
@@ -26,10 +26,11 @@ fn main() {
     println!("Full execution report:\n{:?}", execution_report);
 
     // Read and verify the output.
-    let _ = public_values.read::<u32>();
+    let n = public_values.read::<u32>();
     let a = public_values.read::<u32>();
     let b = public_values.read::<u32>();
 
+    println!("n: {}", n);
     println!("a: {}", a);
     println!("b: {}", b);
 }

--- a/examples/fibonacci/script/src/main.rs
+++ b/examples/fibonacci/script/src/main.rs
@@ -1,4 +1,4 @@
-use zkm2_sdk::{include_elf, utils, ProverClient, ZKM2ProofWithPublicValues, SP1Stdin};
+use zkm2_sdk::{include_elf, utils, ProverClient, ZKMProofWithPublicValues, ZKMStdin};
 
 /// The ELF we want to execute inside the zkVM.
 const ELF: &[u8] = include_elf!("fibonacci-program");
@@ -45,7 +45,7 @@ fn main() {
     // Test a round trip of proof serialization and deserialization.
     proof.save("proof-with-pis.bin").expect("saving proof failed");
     let deserialized_proof =
-        ZKM2ProofWithPublicValues::load("proof-with-pis.bin").expect("loading proof failed");
+        ZKMProofWithPublicValues::load("proof-with-pis.bin").expect("loading proof failed");
 
     // Verify the deserialized proof.
     client.verify(&deserialized_proof, &vk).expect("verification failed");


### PR DESCRIPTION
Run test:
```
zkm2/examples/fibonacci$ cargo run --bin execute
```