### PR TITLE
opt: shard size

### DIFF
--- a/crates/core/executor/src/programs.rs
+++ b/crates/core/executor/src/programs.rs
@@ -8,7 +8,7 @@ pub mod tests {
     use test_artifacts::{
         FIBONACCI_ELF, HELLO_WORLD_ELF,
         KECCAK_PERMUTE_ELF, PANIC_ELF,
-        SECP256R1_ADD_ELF, SECP256R1_DOUBLE_ELF, U256XU2048_MUL_ELF,
+        SECP256R1_ADD_ELF, SECP256R1_DOUBLE_ELF, SHA3_CHAIN_ELF, U256XU2048_MUL_ELF,
     };
 
     #[must_use]
@@ -39,6 +39,16 @@ pub mod tests {
     #[must_use]
     pub fn hello_world_program() -> Program {
         Program::from(HELLO_WORLD_ELF).unwrap()
+    }
+
+    /// Get the sha3-chain program.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if the program fails to load.
+    #[must_use]
+    pub fn sha3_chain_program() -> Program {
+        Program::from(SHA3_CHAIN_ELF).unwrap()
     }
 
     /// Get the secp256r1 add program.

--- a/crates/core/machine/src/mips/mod.rs
+++ b/crates/core/machine/src/mips/mod.rs
@@ -598,7 +598,7 @@ pub mod tests {
 
     use zkm2_core_executor::{
         programs::tests::{
-            fibonacci_program, hello_world_program, simple_memory_program, simple_program, ssz_withdrawals_program,
+            fibonacci_program, hello_world_program, sha3_chain_program, simple_memory_program, simple_program, ssz_withdrawals_program,
         },
         Instruction, Opcode, Program, Register,
     };
@@ -922,6 +922,13 @@ pub mod tests {
     fn test_fibonacci_prove_simple() {
         setup_logger();
         let program = fibonacci_program();
+        run_test::<CpuProver<_, _>>(program).unwrap();
+    }
+
+    #[test]
+    fn test_sha3_chain_prove_simple() {
+        setup_logger();
+        let program = sha3_chain_program();
         run_test::<CpuProver<_, _>>(program).unwrap();
     }
 

--- a/crates/test-artifacts/programs/Cargo.lock
+++ b/crates/test-artifacts/programs/Cargo.lock
@@ -1013,6 +1013,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "keccak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
+dependencies = [
+ "cpufeatures",
+]
+
+[[package]]
 name = "keccak-permute-test"
 version = "1.1.0"
 dependencies = [
@@ -2110,6 +2119,24 @@ dependencies = [
  "hex",
  "hex-literal",
  "sha2 0.10.6",
+ "zkm2-zkvm",
+]
+
+[[package]]
+name = "sha3"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+dependencies = [
+ "digest",
+ "keccak",
+]
+
+[[package]]
+name = "sha3-chain"
+version = "0.1.0"
+dependencies = [
+ "sha3",
  "zkm2-zkvm",
 ]
 

--- a/crates/test-artifacts/programs/Cargo.toml
+++ b/crates/test-artifacts/programs/Cargo.toml
@@ -38,6 +38,7 @@ members = [
   "secp256r1-decompress",
   "secp256r1-double",
   "sha-compress",
+  "sha3-chain",
   "u256x2048-mul",
   "uint256-arith",
   "uint256-mul",

--- a/crates/test-artifacts/programs/sha3-chain/Cargo.toml
+++ b/crates/test-artifacts/programs/sha3-chain/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+version = "0.1.0"
+name = "sha3-chain"
+edition = "2021"
+
+[dependencies]
+zkm2-zkvm = { path = "../../../../crates/zkvm/entrypoint" }
+sha3 = { version = "0.10.8", default-features = false }

--- a/crates/test-artifacts/programs/sha3-chain/src/main.rs
+++ b/crates/test-artifacts/programs/sha3-chain/src/main.rs
@@ -1,0 +1,20 @@
+#![no_std]
+#![no_main]
+
+use sha3::{Digest, Keccak256};
+
+zkm2_zkvm::entrypoint!(main);
+
+pub fn main() {
+    let input = [5u8; 32];
+    let num_iters: u32 = 230;
+    let mut hash = input;
+    for _ in 0..num_iters {
+        let mut hasher = Keccak256::new();
+        hasher.update(input);
+        let res = &hasher.finalize();
+        hash = Into::<[u8; 32]>::into (*res);
+    }
+
+    zkm2_zkvm::io::commit::<[u8; 32]>(&hash.into());
+}

--- a/crates/test-artifacts/src/lib.rs
+++ b/crates/test-artifacts/src/lib.rs
@@ -11,6 +11,7 @@ pub const SHA2_ELF: &[u8] = include_elf!("sha2-test");
 pub const SHA_EXTEND_ELF: &[u8] = include_elf!("sha-extend-test");
 pub const SHA_COMPRESS_ELF: &[u8] = include_elf!("sha-compress-test");
 
+pub const SHA3_CHAIN_ELF: &[u8] = include_elf!("sha3-chain");
 pub const KECCAK256_ELF: &[u8] = include_elf!("keccak256-test");
 pub const KECCAK_PERMUTE_ELF: &[u8] = include_elf!("keccak-permute-test");
 pub const PANIC_ELF: &[u8] = include_elf!("panic-test");


### PR DESCRIPTION
Run Test:
```
RUST_LOG=debug cargo test -r test_fibonacci_prove_simple --features debug
RUST_LOG=debug cargo test -r test_sha3_chain_prove_simple --features debug
```

System:
- Number of Physical CPUs: 1
- Number of Cores per Physical CPU: 8
- Number of Logical CPUs: 16
- Memory: 64 GB

Befor opt: shard_size=524288, shard_batch_size=4
- fibo(n=10000): e2e=64.48810277s, 
- sha3-chain(iters=230): e2e=913.017164456s

After opt: shard_size=2097152, shard_batch_size=1
- fibo(n=10000): e2e=51.752228582s
- sha3-chain(iters=230): e2e=477.920148706s
