### PR TITLE
fix: groth16 example

### DIFF
--- a/crates/verifier/Cargo.toml
+++ b/crates/verifier/Cargo.toml
@@ -16,7 +16,6 @@ sha2 = { version = "0.10.8", default-features = false }
 thiserror = { version = "2", default-features = false }
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 lazy_static = { version = "1.5.0", default-features = false }
-zkm2-sdk = { workspace = true }
 
 # arkworks
 ark-bn254 = { version = "0.5", optional = true }
@@ -27,6 +26,7 @@ ark-ec = { version = "0.5", optional = true }
 
 [dev-dependencies]
 zkm2-prover = { workspace = true }
+zkm2-sdk = { workspace = true }
 test-artifacts = { workspace = true }
 num-bigint = "0.4.6"
 num-traits = "0.2.19"

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -7071,7 +7071,6 @@ dependencies = [
  "sha2 0.10.8",
  "substrate-bn-succinct",
  "thiserror 2.0.12",
- "zkm2-sdk",
 ]
 
 [[package]]


### PR DESCRIPTION
Fix this error:
```
cd zkm2/examples/groth16/host
cargo run -r

[zkm]     Compiling group v0.12.1
[zkm]     Compiling p3-maybe-rayon v0.1.0 (https://github.com/zkMIPS/Plonky3#93967fce)
[zkm]     Compiling const_format v0.2.34
[zkm]     Compiling mio v1.0.3

[zkm]  error[E0432]: unresolved import `crate::sys::IoSourceState`
[zkm]    --> /home/aping/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/mio-1.0.3/src/io_source.rs:14:5
[zkm]     |
[zkm]  14 | use crate::sys::IoSourceState;
[zkm]     |     ^^^^^^^^^^^^^^^^^^^^^^^^^ no `IoSourceState` in `sys`
```