### PR TITLE
chore: change the name of SSL cert and key.

### DIFF
--- a/crates/sdk/src/network/prover.rs
+++ b/crates/sdk/src/network/prover.rs
@@ -56,15 +56,15 @@ impl NetworkProver {
             env::var("CA_CERT_PATH")
                 .unwrap_or(manifest_dir.join("tool/ca.pem").to_string_lossy().to_string()),
         );
-        let cert_path = env::var("CERT_PATH").ok();
-        let key_path = env::var("KEY_PATH").ok();
+        let ssl_cert_path = env::var("SSL_CERT_PATH").ok();
+        let ssl_key_path = env::var("SSL_KEY_PATH").ok();
         let ssl_config = if ca_cert_path.as_ref().is_none() {
             None
         } else {
             let (ca_cert, identity) = get_cert_and_identity(
                 ca_cert_path.as_ref().expect("CA_CERT_PATH not set"),
-                cert_path.as_ref().expect("CERT_PATH not set"),
-                key_path.as_ref().expect("KEY_PATH not set"),
+                ssl_cert_path.as_ref().expect("SSL_CERT_PATH not set"),
+                ssl_key_path.as_ref().expect("SSL_KEY_PATH not set"),
             )?;
             Some(Config { ca_cert, identity })
         };
@@ -248,14 +248,14 @@ impl Prover<DefaultProverComponents> for NetworkProver {
 
 fn get_cert_and_identity(
     ca_cert_path: &str,
-    cert_path: &str,
-    key_path: &str,
+    ssl_cert_path: &str,
+    ssl_key_path: &str,
 ) -> anyhow::Result<(Option<Certificate>, Option<Identity>)> {
     let ca_cert_path = Path::new(ca_cert_path);
-    let cert_path = Path::new(cert_path);
-    let key_path = Path::new(key_path);
+    let cert_path = Path::new(ssl_cert_path);
+    let key_path = Path::new(ssl_key_path);
     if !ca_cert_path.is_file() || !cert_path.is_file() || !key_path.is_file() {
-        bail!("both ca_cert_path, cert_path and key_path should be valid file")
+        bail!("both ca_cert_path, ssl_cert_path and ssl_key_path should be valid file")
     }
     let mut ca: Option<Certificate> = None;
     let mut identity: Option<Identity> = None;

--- a/crates/sdk/tool/certgen.sh
+++ b/crates/sdk/tool/certgen.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-CN=''
+CN='ssl'
 SSL_IP=''
 SSL_DNS=''
 

--- a/docs/src/dev/prover.md
+++ b/docs/src/dev/prover.md
@@ -156,11 +156,11 @@ zkm-sdk = { git = "https://github.com/zkMIPS/zkMIPS", branch = "main" }
 ### Environment Variable Setup
 Before running your application, export the following environment variables to enable the network prover:
 ```bash
-export ZKM_PRIVATE_KEY=<your_private_key>            # Private key corresponding to your registered public key
-export CERT_PATH=<path_to_client_certificate>        # Path to client certificate
-export KEY_PATH=<path_to_client_key>                 # Path to client key
+export ZKM_PRIVATE_KEY=<your_private_key>       # Private key corresponding to your registered public key
+export SSL_CERT_PATH=<path_to_ssl_certificate>  # Path to the SSL client certificate (e.g., ssl.pem)
+export SSL_KEY_PATH=<path_to_ssl_key>           # Path to the SSL client private key (e.g., ssl.key)
 ```
-You can generate the client certificate and key by running the [`certgen.sh`](https://github.com/VanhGer/zkMIPS/blob/feat/network-prover/crates/sdk/tool/certgen.sh) script.
+You can generate the SSL certificate and key by running the [`certgen.sh`](https://github.com/zkMIPS/zkMIPS/blob/main/crates/sdk/tool/certgen.sh) script.
 
 To host your own network prover, export the following variables to configure your endpoint:
 ```bash


### PR DESCRIPTION
Purpose: to avoid misleading use of the terms 'cert' and 'key' in environment variables.