### PR TITLE
fix: formatted for link in `stark.md`

### DIFF
--- a/docs/src/design/stark.md
+++ b/docs/src/design/stark.md
@@ -2,7 +2,7 @@
 
 ## Polynomial Constraint System Architecture
 
-Following [arithmetization]((./arithmetization.md)), the computation is represented through a structured polynomial system.
+Following [arithmetization](./arithmetization.md), the computation is represented through a structured polynomial system.
 
 ### Core Components
 - ​Execution Trace Polynomials


### PR DESCRIPTION
Hey! Just a quick fix — corrected the markdown formatting for the link to `arithmetization.md` in `stark.md`. Removed an extra pair of parentheses so the link now renders properly.