### PR TITLE
ci: remove scheduled ci

### DIFF
--- a/.github/workflows/ci_time_consuming.yml
+++ b/.github/workflows/ci_time_consuming.yml
@@ -1,10 +1,8 @@
-name: Scheduled CI
+name: Time-consuming test
 
 on:
   push:
     branches: ["main"]
-  schedule:
-    - cron: '0 20 * * *'
   workflow_dispatch:
 
 env:

--- a/crates/stark/src/air/builder.rs
+++ b/crates/stark/src/air/builder.rs
@@ -64,7 +64,7 @@ impl<AB: EmptyMessageBuilder, M> MessageBuilder<M> for AB {
 /// A trait which contains basic methods for building an AIR.
 pub trait BaseAirBuilder: AirBuilder + MessageBuilder<AirLookup<Self::Expr>> {
     /// Returns a sub-builder whose constraints are enforced only when `condition` is not one.
-    fn when_not<I: Into<Self::Expr>>(&mut self, condition: I) -> FilteredAirBuilder<Self> {
+    fn when_not<I: Into<Self::Expr>>(&mut self, condition: I) -> FilteredAirBuilder<'_, Self> {
         self.when_ne(condition, Self::F::ONE)
     }
 


### PR DESCRIPTION
Time-consuming tests will be executed when a PR is merged into the main branch, so there's no need to run them daily.