### PR TITLE
style: refactor prove interface

### DIFF
--- a/crates/sdk/src/action.rs
+++ b/crates/sdk/src/action.rs
@@ -131,7 +131,7 @@ impl<'a> Prove<'a> {
         // Dump the program and stdin to files for debugging if `ZKM_DUMP` is set.
         crate::utils::zkm_dump(&pk.elf, &stdin);
 
-        prover.prove(pk, stdin, proof_opts, context, kind)
+        prover.prove_impl(pk, stdin, proof_opts, context, kind)
     }
 
     /// Set the proof kind to the core mode. This is the default.

--- a/crates/sdk/src/network/prover.rs
+++ b/crates/sdk/src/network/prover.rs
@@ -246,7 +246,7 @@ impl Prover<DefaultProverComponents> for NetworkProver {
     }
 
     /// The proof network can generate Compressed or Groth16 proof.
-    fn prove<'a>(
+    fn prove_impl<'a>(
         &'a self,
         pk: &ZKMProvingKey,
         stdin: ZKMStdin,

--- a/crates/sdk/src/provers/cpu.rs
+++ b/crates/sdk/src/provers/cpu.rs
@@ -42,7 +42,7 @@ impl Prover<DefaultProverComponents> for CpuProver {
         &self.prover
     }
 
-    fn prove<'a>(
+    fn prove_impl<'a>(
         &'a self,
         pk: &ZKMProvingKey,
         stdin: ZKMStdin,

--- a/crates/sdk/src/provers/mock.rs
+++ b/crates/sdk/src/provers/mock.rs
@@ -47,7 +47,7 @@ impl Prover<DefaultProverComponents> for MockProver {
         &self.prover
     }
 
-    fn prove<'a>(
+    fn prove_impl<'a>(
         &'a self,
         pk: &ZKMProvingKey,
         stdin: ZKMStdin,

--- a/crates/sdk/src/provers/mod.rs
+++ b/crates/sdk/src/provers/mod.rs
@@ -87,6 +87,22 @@ pub trait Prover<C: ZKMProverComponents>: Send + Sync {
         &'a self,
         pk: &ZKMProvingKey,
         stdin: ZKMStdin,
+        kind: ZKMProofKind,
+    ) -> Result<ZKMProofWithPublicValues> {
+        self.prove_impl(
+            pk,
+            stdin,
+            ProofOpts::default(),
+            ZKMContext::default(),
+            kind,
+        )
+    }
+
+    /// Prove the execution of a MIPS ELF with the given inputs, according to the given proof mode.
+    fn prove_impl<'a>(
+        &'a self,
+        pk: &ZKMProvingKey,
+        stdin: ZKMStdin,
         opts: ProofOpts,
         context: ZKMContext<'a>,
         kind: ZKMProofKind,
@@ -196,7 +212,7 @@ impl Prover<DefaultProverComponents> for ProverClient {
         self.prover.setup(elf)
     }
 
-    fn prove<'a>(
+    fn prove_impl<'a>(
         &'a self,
         pk: &ZKMProvingKey,
         stdin: ZKMStdin,
@@ -204,7 +220,7 @@ impl Prover<DefaultProverComponents> for ProverClient {
         context: ZKMContext<'a>,
         kind: ZKMProofKind,
     ) -> Result<ZKMProofWithPublicValues> {
-        self.prover.prove(pk, stdin, opts, context, kind)
+        self.prover.prove_impl(pk, stdin, opts, context, kind)
     }
 
     fn verify(

--- a/crates/sdk/src/provers/mod.rs
+++ b/crates/sdk/src/provers/mod.rs
@@ -83,19 +83,13 @@ pub trait Prover<C: ZKMProverComponents>: Send + Sync {
     fn setup(&self, elf: &[u8]) -> (ZKMProvingKey, ZKMVerifyingKey);
 
     /// Prove the execution of a MIPS ELF with the given inputs, according to the given proof mode.
-    fn prove<'a>(
-        &'a self,
+    fn prove(
+        &self,
         pk: &ZKMProvingKey,
         stdin: ZKMStdin,
         kind: ZKMProofKind,
     ) -> Result<ZKMProofWithPublicValues> {
-        self.prove_impl(
-            pk,
-            stdin,
-            ProofOpts::default(),
-            ZKMContext::default(),
-            kind,
-        )
+        self.prove_impl(pk, stdin, ProofOpts::default(), ZKMContext::default(), kind)
     }
 
     /// Prove the execution of a MIPS ELF with the given inputs, according to the given proof mode.


### PR DESCRIPTION
Previous calling method:

```rust
client.prove(pk.as_ref(), stdin, Default::default(), Default::default(), prove_mode)?
```

Current calling method:

```rust
client.prove(pk.as_ref(), stdin, prove_mode)?
```

