### PR TITLE
Minor Documentation and Syntax Corrections

### DIFF
--- a/crates/core/machine/src/misc/columns/maddsub.rs
+++ b/crates/core/machine/src/misc/columns/maddsub.rs
@@ -19,6 +19,6 @@ pub struct MaddsubCols<T> {
     pub src2_hi: Word<T>,
     pub src2_lo: Word<T>,
 
-    /// Access to hi regiter
+    /// Access to hi register
     pub op_hi_access: MemoryReadWriteCols<T>,
 }

--- a/crates/zkvm/entrypoint/src/memset.s
+++ b/crates/zkvm/entrypoint/src/memset.s
@@ -173,7 +173,7 @@
 // All other files which have no copyright comments are original works
 // produced specifically for use as part of this library, written either
 // by Rich Felker, the main author of the library, or by one or more
-// contibutors listed above. Details on authorship of individual files
+// contributors listed above. Details on authorship of individual files
 // can be found in the git version control history of the project. The
 // omission of copyright and license comments in each file is in the
 // interest of source tree size.


### PR DESCRIPTION


Description:  
This pull request includes minor corrections in documentation and code syntax:
- Fixed a typo in the comment for the hi register in `maddsub.rs`.
- Corrected the spelling of "contributors" in a comment in `memset.s`.
- Adjusted the `.addrsig` directive formatting in `memset.s` for consistency.

No functional changes were made; these are purely for clarity and code quality.