### PR TITLE
Fix Typos in Comments and Documentation

### DIFF
--- a/crates/core/machine/src/alu/mul/mod.rs
+++ b/crates/core/machine/src/alu/mul/mod.rs
@@ -122,7 +122,7 @@ pub struct MulCols<T> {
     /// Selector to know whether this row is enabled.
     pub is_real: T,
 
-    /// Access to hi regiter
+    /// Access to hi register
     pub op_hi_access: MemoryReadWriteCols<T>,
 
     /// Flag indicating whether the hi_access record is real.

--- a/crates/zkvm/entrypoint/src/memcpy.s
+++ b/crates/zkvm/entrypoint/src/memcpy.s
@@ -173,7 +173,7 @@
 // All other files which have no copyright comments are original works
 // produced specifically for use as part of this library, written either
 // by Rich Felker, the main author of the library, or by one or more
-// contibutors listed above. Details on authorship of individual files
+// contributors listed above. Details on authorship of individual files
 // can be found in the git version control history of the project. The
 // omission of copyright and license comments in each file is in the
 // interest of source tree size.


### PR DESCRIPTION

Description:  
This pull request corrects minor typographical errors in the codebase. Specifically, it fixes the spelling of "register" in a comment within `mul.rs` and "contributors" in a comment within `memcpy.s`. These changes improve the clarity and professionalism of the documentation without affecting any functionality.