### PR TITLE
style: refactor interface prove_with_cycles into a generic interface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       - run: curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/zkMIPS/toolchain/refs/heads/main/setup.sh | sh
       - run: source ~/.zkm-toolchain/env && cd crates/test-artifacts && cargo build && cd ../..
       - name: Install Dependencies
-        run: sudo apt install protobuf-compiler
+        run: sudo apt update && sudo apt install protobuf-compiler
       - run: cargo clippy --all-targets -- -D warnings
   test:
     name: Cargo Test

--- a/crates/sdk/src/action.rs
+++ b/crates/sdk/src/action.rs
@@ -131,7 +131,7 @@ impl<'a> Prove<'a> {
         // Dump the program and stdin to files for debugging if `ZKM_DUMP` is set.
         crate::utils::zkm_dump(&pk.elf, &stdin);
 
-        prover.prove_impl(pk, stdin, proof_opts, context, kind)
+        prover.prove_impl(pk, stdin, proof_opts, context, kind, None)
     }
 
     /// Set the proof kind to the core mode. This is the default.

--- a/crates/sdk/src/provers/cpu.rs
+++ b/crates/sdk/src/provers/cpu.rs
@@ -84,6 +84,7 @@ impl Prover<DefaultProverComponents> for CpuProver {
         opts: ProofOpts,
         context: ZKMContext<'a>,
         kind: ZKMProofKind,
+        _elf_id: Option<String>,
     ) -> Result<ZKMProofWithPublicValues> {
         if kind == ZKMProofKind::CompressToGroth16 {
             return self.compress_to_groth16(stdin, opts);

--- a/crates/sdk/src/provers/mock.rs
+++ b/crates/sdk/src/provers/mock.rs
@@ -54,6 +54,7 @@ impl Prover<DefaultProverComponents> for MockProver {
         opts: ProofOpts,
         context: ZKMContext<'a>,
         kind: ZKMProofKind,
+        _elf_id: Option<String>,
     ) -> Result<ZKMProofWithPublicValues> {
         match kind {
             ZKMProofKind::Core => {


### PR DESCRIPTION
Refactor interface `prove_with_cycles` into a generic interface.

Usage:
```rust
-    #[cfg(feature = "network_prover")]
-    let client = {
-        let np = NetworkProver::from_env().map_err(|_| {
-            eyre::eyre!("Failed to create NetworkProver from environment variables")
-        })?;
-        Arc::new(np)
-    };
-    #[cfg(not(feature = "network_prover"))]
-    let client = {
-        info!("Use local ProverClient");
-        Arc::new(ProverClient::new())
-    };

+    let client = Arc::new(ProverClient::new());

client.prove_with_cycles(&pk, &stdin, prove_mode, elf_id);
```