### PR TITLE
style: prove_with_cycles() interface must return cycles

### DIFF
--- a/crates/sdk/src/action.rs
+++ b/crates/sdk/src/action.rs
@@ -131,7 +131,7 @@ impl<'a> Prove<'a> {
         // Dump the program and stdin to files for debugging if `ZKM_DUMP` is set.
         crate::utils::zkm_dump(&pk.elf, &stdin);
 
-        prover.prove_impl(pk, stdin, proof_opts, context, kind, None)
+        Ok(prover.prove_impl(pk, stdin, proof_opts, context, kind, None)?.0)
     }
 
     /// Set the proof kind to the core mode. This is the default.

--- a/crates/sdk/src/network/prover.rs
+++ b/crates/sdk/src/network/prover.rs
@@ -296,19 +296,8 @@ impl Prover<DefaultProverComponents> for NetworkProver {
         _context: ZKMContext<'a>,
         kind: ZKMProofKind,
         elf_id: Option<String>,
-    ) -> Result<ZKMProofWithPublicValues> {
-        block_on(self.prove_with_cycles(&pk.elf, stdin, kind, elf_id, None)).map(|(proof, _)| proof)
-    }
-
-    fn prove_with_cycles(
-        &self,
-        pk: &ZKMProvingKey,
-        stdin: &ZKMStdin,
-        kind: ZKMProofKind,
-        elf_id: Option<String>, // The SHA-256 hash of the ELF, without the 0x prefix
-    ) -> Result<(ZKMProofWithPublicValues, Option<u64>)> {
-        block_on(self.prove_with_cycles(&pk.elf, stdin.clone(), kind, elf_id, None))
-            .map(|(proof, cycles)| (proof, Some(cycles)))
+    ) -> Result<(ZKMProofWithPublicValues, u64)> {
+        block_on(self.prove_with_cycles(&pk.elf, stdin, kind, elf_id, None))
     }
 }
 

--- a/crates/sdk/src/provers/cpu.rs
+++ b/crates/sdk/src/provers/cpu.rs
@@ -85,21 +85,25 @@ impl Prover<DefaultProverComponents> for CpuProver {
         context: ZKMContext<'a>,
         kind: ZKMProofKind,
         _elf_id: Option<String>,
-    ) -> Result<ZKMProofWithPublicValues> {
+    ) -> Result<(ZKMProofWithPublicValues, u64)> {
         if kind == ZKMProofKind::CompressToGroth16 {
-            return self.compress_to_groth16(stdin, opts);
+            return Ok((self.compress_to_groth16(stdin, opts)?, 0));
         }
 
         // Generate the core proof.
         let proof: zkm_prover::ZKMProofWithMetadata<zkm_prover::ZKMCoreProofData> =
             self.prover.prove_core(pk, &stdin, opts.zkm_prover_opts, context)?;
+        let cycles = proof.cycles;
         if kind == ZKMProofKind::Core {
-            return Ok(ZKMProofWithPublicValues {
-                proof: ZKMProof::Core(proof.proof.0),
-                stdin: proof.stdin,
-                public_values: proof.public_values,
-                zkm_version: self.version().to_string(),
-            });
+            return Ok((
+                ZKMProofWithPublicValues {
+                    proof: ZKMProof::Core(proof.proof.0),
+                    stdin: proof.stdin,
+                    public_values: proof.public_values,
+                    zkm_version: self.version().to_string(),
+                },
+                cycles,
+            ));
         }
 
         let deferred_proofs =
@@ -110,12 +114,15 @@ impl Prover<DefaultProverComponents> for CpuProver {
         let reduce_proof =
             self.prover.compress(&pk.vk, proof, deferred_proofs, opts.zkm_prover_opts)?;
         if kind == ZKMProofKind::Compressed {
-            return Ok(ZKMProofWithPublicValues {
-                proof: ZKMProof::Compressed(Box::new(reduce_proof)),
-                stdin,
-                public_values,
-                zkm_version: self.version().to_string(),
-            });
+            return Ok((
+                ZKMProofWithPublicValues {
+                    proof: ZKMProof::Compressed(Box::new(reduce_proof)),
+                    stdin,
+                    public_values,
+                    zkm_version: self.version().to_string(),
+                },
+                cycles,
+            ));
         }
 
         // Generate the shrink proof.
@@ -135,12 +142,15 @@ impl Prover<DefaultProverComponents> for CpuProver {
             };
             let proof = self.prover.wrap_plonk_bn254(outer_proof, &plonk_bn254_artifacts);
 
-            return Ok(ZKMProofWithPublicValues {
-                proof: ZKMProof::Plonk(proof),
-                stdin,
-                public_values,
-                zkm_version: self.version().to_string(),
-            });
+            return Ok((
+                ZKMProofWithPublicValues {
+                    proof: ZKMProof::Plonk(proof),
+                    stdin,
+                    public_values,
+                    zkm_version: self.version().to_string(),
+                },
+                cycles,
+            ));
         } else if kind == ZKMProofKind::Groth16 {
             let groth16_bn254_artifacts = if zkm_prover::build::zkm_dev_mode() {
                 zkm_prover::build::try_build_groth16_bn254_artifacts_dev(
@@ -152,12 +162,15 @@ impl Prover<DefaultProverComponents> for CpuProver {
             };
 
             let proof = self.prover.wrap_groth16_bn254(outer_proof, &groth16_bn254_artifacts);
-            return Ok(ZKMProofWithPublicValues {
-                proof: ZKMProof::Groth16(proof),
-                stdin,
-                public_values,
-                zkm_version: self.version().to_string(),
-            });
+            return Ok((
+                ZKMProofWithPublicValues {
+                    proof: ZKMProof::Groth16(proof),
+                    stdin,
+                    public_values,
+                    zkm_version: self.version().to_string(),
+                },
+                cycles,
+            ));
         }
 
         unreachable!()

--- a/crates/sdk/src/provers/mock.rs
+++ b/crates/sdk/src/provers/mock.rs
@@ -55,16 +55,19 @@ impl Prover<DefaultProverComponents> for MockProver {
         context: ZKMContext<'a>,
         kind: ZKMProofKind,
         _elf_id: Option<String>,
-    ) -> Result<ZKMProofWithPublicValues> {
+    ) -> Result<(ZKMProofWithPublicValues, u64)> {
         match kind {
             ZKMProofKind::Core => {
                 let (public_values, _) = self.prover.execute(&pk.elf, &stdin, context)?;
-                Ok(ZKMProofWithPublicValues {
-                    proof: ZKMProof::Core(vec![]),
-                    stdin,
-                    public_values,
-                    zkm_version: self.version().to_string(),
-                })
+                Ok((
+                    ZKMProofWithPublicValues {
+                        proof: ZKMProof::Core(vec![]),
+                        stdin,
+                        public_values,
+                        zkm_version: self.version().to_string(),
+                    },
+                    0,
+                ))
             }
             ZKMProofKind::Compressed => {
                 let (public_values, _) = self.prover.execute(&pk.elf, &stdin, context)?;
@@ -99,46 +102,55 @@ impl Prover<DefaultProverComponents> for MockProver {
                     proof: shard_proof,
                 }));
 
-                Ok(ZKMProofWithPublicValues {
-                    proof,
-                    stdin,
-                    public_values,
-                    zkm_version: self.version().to_string(),
-                })
+                Ok((
+                    ZKMProofWithPublicValues {
+                        proof,
+                        stdin,
+                        public_values,
+                        zkm_version: self.version().to_string(),
+                    },
+                    0,
+                ))
             }
             ZKMProofKind::Plonk => {
                 let (public_values, _) = self.prover.execute(&pk.elf, &stdin, context)?;
-                Ok(ZKMProofWithPublicValues {
-                    proof: ZKMProof::Plonk(PlonkBn254Proof {
-                        public_inputs: [
-                            pk.vk.hash_bn254().as_canonical_biguint().to_string(),
-                            public_values.hash_bn254().to_string(),
-                        ],
-                        encoded_proof: "".to_string(),
-                        raw_proof: "".to_string(),
-                        plonk_vkey_hash: [0; 32],
-                    }),
-                    stdin,
-                    public_values,
-                    zkm_version: self.version().to_string(),
-                })
+                Ok((
+                    ZKMProofWithPublicValues {
+                        proof: ZKMProof::Plonk(PlonkBn254Proof {
+                            public_inputs: [
+                                pk.vk.hash_bn254().as_canonical_biguint().to_string(),
+                                public_values.hash_bn254().to_string(),
+                            ],
+                            encoded_proof: "".to_string(),
+                            raw_proof: "".to_string(),
+                            plonk_vkey_hash: [0; 32],
+                        }),
+                        stdin,
+                        public_values,
+                        zkm_version: self.version().to_string(),
+                    },
+                    0,
+                ))
             }
             ZKMProofKind::Groth16 => {
                 let (public_values, _) = self.prover.execute(&pk.elf, &stdin, context)?;
-                Ok(ZKMProofWithPublicValues {
-                    proof: ZKMProof::Groth16(Groth16Bn254Proof {
-                        public_inputs: [
-                            pk.vk.hash_bn254().as_canonical_biguint().to_string(),
-                            public_values.hash_bn254().to_string(),
-                        ],
-                        encoded_proof: "".to_string(),
-                        raw_proof: "".to_string(),
-                        groth16_vkey_hash: [0; 32],
-                    }),
-                    stdin,
-                    public_values,
-                    zkm_version: self.version().to_string(),
-                })
+                Ok((
+                    ZKMProofWithPublicValues {
+                        proof: ZKMProof::Groth16(Groth16Bn254Proof {
+                            public_inputs: [
+                                pk.vk.hash_bn254().as_canonical_biguint().to_string(),
+                                public_values.hash_bn254().to_string(),
+                            ],
+                            encoded_proof: "".to_string(),
+                            raw_proof: "".to_string(),
+                            groth16_vkey_hash: [0; 32],
+                        }),
+                        stdin,
+                        public_values,
+                        zkm_version: self.version().to_string(),
+                    },
+                    0,
+                ))
             }
             ZKMProofKind::CompressToGroth16 => unreachable!(),
         }

--- a/crates/sdk/src/provers/mod.rs
+++ b/crates/sdk/src/provers/mod.rs
@@ -89,7 +89,9 @@ pub trait Prover<C: ZKMProverComponents>: Send + Sync {
         stdin: ZKMStdin,
         kind: ZKMProofKind,
     ) -> Result<ZKMProofWithPublicValues> {
-        self.prove_impl(pk, stdin, ProofOpts::default(), ZKMContext::default(), kind, None)
+        let proof =
+            self.prove_impl(pk, stdin, ProofOpts::default(), ZKMContext::default(), kind, None)?;
+        Ok(proof.0)
     }
 
     /// Prove the execution of a MIPS ELF with the given inputs, according to the given proof mode.
@@ -102,16 +104,15 @@ pub trait Prover<C: ZKMProverComponents>: Send + Sync {
         stdin: &ZKMStdin,
         kind: ZKMProofKind,
         elf_id: Option<String>,
-    ) -> Result<(ZKMProofWithPublicValues, Option<u64>)> {
-        let proof = self.prove_impl(
+    ) -> Result<(ZKMProofWithPublicValues, u64)> {
+        self.prove_impl(
             pk,
             stdin.clone(),
             ProofOpts::default(),
             ZKMContext::default(),
             kind,
             elf_id,
-        )?;
-        Ok((proof, None))
+        )
     }
 
     /// Prove the execution of a MIPS ELF with the given inputs, according to the given proof mode.
@@ -123,7 +124,7 @@ pub trait Prover<C: ZKMProverComponents>: Send + Sync {
         context: ZKMContext<'a>,
         kind: ZKMProofKind,
         elf_id: Option<String>,
-    ) -> Result<ZKMProofWithPublicValues>;
+    ) -> Result<(ZKMProofWithPublicValues, u64)>;
 
     /// Verify that a Ziren proof is valid given its vkey and metadata.
     /// For Plonk proofs, verifies that the public inputs of the PlonkBn254 proof match
@@ -238,7 +239,7 @@ impl Prover<DefaultProverComponents> for ProverClient {
         context: ZKMContext<'a>,
         kind: ZKMProofKind,
         elf_id: Option<String>,
-    ) -> Result<ZKMProofWithPublicValues> {
+    ) -> Result<(ZKMProofWithPublicValues, u64)> {
         self.prover.prove_impl(pk, stdin, opts, context, kind, elf_id)
     }
 


### PR DESCRIPTION
`prove_with_cycles()` interface must return cycles.