### PR TITLE
fix: correct typos in core executor and machine modules

### DIFF
--- a/crates/core/executor/src/hook.rs
+++ b/crates/core/executor/src/hook.rs
@@ -521,11 +521,11 @@ mod bls {
 
     /// Given a field element, in big endian, this function computes the inverse.
     ///
-    /// This functions will panic if the additive identity is passed in.
+    /// This function will panic if the additive identity is passed in.
     pub fn hook_bls12_381_inverse(_: HookEnv, buf: &[u8]) -> Vec<Vec<u8>> {
         let field_element = BigUint::from_bytes_be(&buf[..48]);
 
-        // Zero is not invertible, and we dont want to have to return a status from here.
+        // Zero is not invertible, and we don't want to have to return a status from here.
         assert!(!field_element.is_zero(), "Field element is the additive identity");
 
         let modulus = BigUint::from_bytes_le(BLS12_381_MODULUS);

--- a/crates/core/machine/src/alu/divrem/mod.rs
+++ b/crates/core/machine/src/alu/divrem/mod.rs
@@ -690,7 +690,7 @@ where
                     + local.is_modu * modu
             };
 
-            // DivRem Chip is only used for DIV and DIVU instruction currently. So is_write_hi will always be ture.
+            // DivRem Chip is only used for DIV and DIVU instruction currently. So is_write_hi will always be true.
             builder.receive_instruction(
                 local.shard,
                 local.clk,

--- a/crates/core/machine/src/alu/lt/mod.rs
+++ b/crates/core/machine/src/alu/lt/mod.rs
@@ -72,7 +72,7 @@ pub struct LtCols<T> {
 
     /// The result of the intermediate SLTU operation `b_comp < c_comp`.
     pub sltu: T,
-    /// A bollean flag for an intermediate comparison.
+    /// A boolean flag for an intermediate comparison.
     pub is_comp_eq: T,
     /// A boolean flag for comparing the sign bits.
     pub is_sign_eq: T,


### PR DESCRIPTION
crates/core/executor/src/hook.rs:

- Fixed "functions" → "function" in doc comment.

- Added apostrophe in "don't" for grammatical correctness.

crates/core/machine/src/alu/divrem/mod.rs:

- Corrected "ture" → "true" in comment.

crates/core/machine/src/alu/lt/mod.rs:

- Fixed spelling "bollean" → "boolean" in comment.