### PR TITLE
docs: correct typos in uint256 and weierstrass precompile comments

### DIFF
--- a/crates/core/machine/src/syscall/precompiles/uint256/air.rs
+++ b/crates/core/machine/src/syscall/precompiles/uint256/air.rs
@@ -272,7 +272,7 @@ where
             local.is_real,
         );
 
-        // Verify the range of the output if the moduls is not zero.  Also, check the value of
+        // Verify the range of the output if the modulus is not zero.  Also, check the value of
         // modulus_is_not_zero.
         local.output_range_check.eval(
             builder,

--- a/crates/core/machine/src/syscall/precompiles/weierstrass/weierstrass_decompress.rs
+++ b/crates/core/machine/src/syscall/precompiles/weierstrass/weierstrass_decompress.rs
@@ -390,7 +390,7 @@ where
                 // the result is greater than or less its negative with respect to the lexicographic
                 // ordering, embedding prime field values as integers.
                 //
-                // In order to endorce these constraints, we will use the auxiliary choice columns.
+                // In order to enforce these constraints, we will use the auxiliary choice columns.
 
                 // Get the choice columns from the row slice
                 let choice_cols: &LexicographicChoiceCols<AB::Var, E::BaseField> = (*local_slice)


### PR DESCRIPTION
- In uint256/air.rs: fixed "moduls" → "modulus".
- In weierstrass_decompress.rs: corrected "endorce" → "enforce".

