### PR TITLE
fix: correct typos in comments

### DIFF
--- a/docs/src/dev/prover.md
+++ b/docs/src/dev/prover.md
@@ -151,7 +151,7 @@ Each stage may take a different amount of time.
 - [Register](https://www.zkm.io/apply) your address to gain access.
 - **SDK dependency**: add `zkm_sdk` from the Ziren SDK to your `Cargo.toml`:
 ```toml
-zkm-sdk = { git = "https://github.com/ProjectZKM/Ziren", branch = "main" }
+zkm-sdk = { git = "https://github.com/ProjectZKM/Ziren" }
 ```
 ### Environment Variable Setup
 Before running your application, export the following environment variables to enable the network prover:

--- a/examples/regex/host/src/main.rs
+++ b/examples/regex/host/src/main.rs
@@ -7,7 +7,7 @@ fn main() {
     // Setup a tracer for logging.
     utils::setup_logger();
 
-    // Create a new stdin with d the input for the program.
+    // Create a new stdin with the input for the program.
     let mut stdin = ZKMStdin::new();
 
     let pattern = "a+".to_string();

--- a/examples/ssz-withdrawals/guest/src/beacon/hints.rs
+++ b/examples/ssz-withdrawals/guest/src/beacon/hints.rs
@@ -6,7 +6,7 @@ use hex_literal::hex;
 use ssz_rs::prelude::*;
 use std::hint::black_box;
 
-/// Returns the beaacon block's withdrawals root and a corresponding SSZ merkle proof.
+/// Returns the beacon block's withdrawals root and a corresponding SSZ merkle proof.
 pub fn withdrawals_root_proof(_block_root: Node) -> (Node, Vec<Node>) {
     let leaf =
         node_from_bytes(hex!("5cc52fb136d9ff526f071f8f87d44c3f35ff5dc973371a2c3613d8ecc53bfcd4"));


### PR DESCRIPTION
examples/regex/host/src/main.rs: fixed typo "d the input" → "the input" in comment.

examples/ssz-withdrawals/guest/src/beacon/hints.rs: fixed typo "beaacon" → "beacon" in comment.