### PR TITLE
docs: fix typos in developer documentation

### DIFF
--- a/docs/src/dev/example-program.md
+++ b/docs/src/dev/example-program.md
@@ -146,7 +146,7 @@ fn main() {
         // Generate the Core proof
         let proof = if args.core {
             client.prove(&pk, stdin).run().expect("failed to generate Core proof")
-        // generats compressed proof 
+        // generates compressed proof 
         } else {
             client
                 .prove(&pk, stdin)

--- a/docs/src/dev/precompiles.md
+++ b/docs/src/dev/precompiles.md
@@ -51,7 +51,7 @@ extern "C" {
     /// Executes an Ed25519 curve decompression on the given point.
     pub fn syscall_ed_decompress(point: &mut [u8; 64]);
 
-    /// Executes an Sepc256k1 curve addition on the given points.
+    /// Executes an Secp256k1 curve addition on the given points.
     pub fn syscall_secp256k1_add(p: *mut [u32; 16], q: *const [u32; 16]);
 
     /// Executes an Secp256k1 curve doubling on the given point.


### PR DESCRIPTION
- Corrected "generats" → "generates" in example-program.md.  
- Fixed typo "Sepc256k1" → "Secp256k1" in precompiles.md.  