### PR TITLE
Fix typos and improve comments in core executor & machine docs

### DIFF
--- a/crates/core/executor/src/events/cpu.rs
+++ b/crates/core/executor/src/events/cpu.rs
@@ -28,9 +28,9 @@ pub struct CpuEvent {
     pub c: u32,
     /// The third operand memory record.
     pub c_record: Option<MemoryRecordEnum>,
-    /// The forth operand.
+    /// The fourth operand.
     pub hi: Option<u32>,
-    /// The forth operand memory record.
+    /// The fourth operand memory record.
     pub hi_record: Option<MemoryRecordEnum>,
     /// The memory record.
     pub memory_record: Option<MemoryRecordEnum>,

--- a/crates/core/executor/src/events/instr.rs
+++ b/crates/core/executor/src/events/instr.rs
@@ -261,7 +261,7 @@ pub struct MiscEvent {
 }
 
 impl MiscEvent {
-    /// Create a new [`JumpEvent`].
+    /// Create a new [`MiscEvent`].
     #[must_use]
     #[allow(clippy::too_many_arguments)]
     pub fn new(

--- a/crates/core/machine/src/syscall/precompiles/README.md
+++ b/crates/core/machine/src/syscall/precompiles/README.md
@@ -5,7 +5,7 @@ more efficiently.
 
 ## Create the Chip
 
-Create a new rust Rust file for your chip in the `core/src/syscall/precompiles` directory.
+Create a new Rust file for your chip in the `core/src/syscall/precompiles` directory.
 
 ### Define the Chip Struct:
 


### PR DESCRIPTION
cpu.rs: Fixed spelling (forth → fourth) for operand and memory record comments.

instr.rs: Corrected doc comment to reference MiscEvent instead of JumpEvent.

precompiles/README.md: Removed redundant word ("rust Rust" → "Rust").