### PR TITLE
chore: Use workspace tracing-subscriber in core/executor

### DIFF
--- a/crates/core/executor/Cargo.toml
+++ b/crates/core/executor/Cargo.toml
@@ -47,7 +47,7 @@ vec_map = { version = "0.8.2", features = ["serde"] }
 enum-map = { version = "2.7.3", features = ["serde"] }
 sha2 = { workspace = true }
 anyhow = { workspace = true }
-tracing-subscriber = "0.3.19"
+ tracing-subscriber = { workspace = true }
 env_logger = "0.11.6"
 
 [dev-dependencies]


### PR DESCRIPTION
## Description

Switch core/executor from tracing-subscriber = "0.3.19" to { workspace = true }, matching the workspace version (0.3.17). This removes intra-workspace version drift, avoids duplicate crates in cargo tree, and keeps features/logging behavior consistent across crates. No code paths change. Build and lints pass; cargo tree -d shows a single tracing-subscriber after this change.