### PR TITLE
Fix Documentation Typos

### DIFF
--- a/docs/src/design/arithmetization.md
+++ b/docs/src/design/arithmetization.md
@@ -90,7 +90,7 @@ The corresponding constraints support (we use op_1, op_2, add_op for short of op
 - range check
   8-bits values for op_1.i, op_2.i, add_op.value.i. e.g., \\(op\\_1.0 \in \\{0,1,2,\cdots,255\\}\\).
 
-### Matrix Polulation
+### Matrix Population
 
 Sample register state evolution:
 

--- a/docs/src/design/chips/cpu.md
+++ b/docs/src/design/chips/cpu.md
@@ -28,7 +28,7 @@ Ziren's CPU constraints ensure instruction integrity across four key dimensions:
   
   Validates operand sources (register/immediate distinction) and enforces zero-value rules under specific conditions.
 
-- ​Memory Consisetency Constraints​​
+- Memory Consistency Constraints
   
   Address validity: Verify memory address validity.
   Value consistency: Verify memory consistency checking.

--- a/docs/src/design/chips/flow-ctrl.md
+++ b/docs/src/design/chips/flow-ctrl.md
@@ -37,7 +37,7 @@ We use the following key constraints to validate the branch chip:
   - Opcode validity is enforced through linear combination verification.
 
 - Branch Condition Logic
-  `is_branching` and `not_branching` consistent whti condition flags.
+  `is_branching` and `not_branching` consistent with condition flags.
 
 ## Jump Chip
 

--- a/docs/src/design/chips/state-machine.md
+++ b/docs/src/design/chips/state-machine.md
@@ -14,7 +14,7 @@ Core Components:
 
 - ALU Chips
    
-  The ALU chips manage common field operations and bitwise operations. These chips are responsible for verifying correctness of arithmetic and bitwise operations and throug corss-table lookups from the main CPU chip to make sure executing the correct instructions.
+  The ALU chips manage common field operations and bitwise operations. These chips are responsible for verifying correctness of arithmetic and bitwise operations and through cross-table lookups from the main CPU chip to make sure executing the correct instructions.
 
 - Flow-Control Chips
   

--- a/docs/src/dev/verifier.md
+++ b/docs/src/dev/verifier.md
@@ -370,7 +370,7 @@ This example logs:
 - Verification time (in ms)
 - Whether the proof is valid
 
-The `eth_wasm` example demonstrates **in-browser STARK verification for Ethereum block proofs** as part of the [EthProofs](https://ethproofs.org/?utm_source=chatgpt.com) initiatve. 
+The `eth_wasm` example demonstrates **in-browser STARK verification for Ethereum block proofs** as part of the [EthProofs](https://ethproofs.org/?utm_source=chatgpt.com) initiate. 
 
 main.js: 
 


### PR DESCRIPTION
Corrects spelling errors in documentation files:

- `arithmetization.md`: Polulation → Population
- `cpu.md`: Consisetency → Consistency
- `flow-ctrl.md`: whti → with
- `state-machine.md`: throug corss-table → through cross-table
- `verifier.md`: initiatve → initiate

These typos affected readability and professionalism of the technical documentation.