### PR TITLE
Fix typos in code comments and documentation

### DIFF
--- a/crates/stark/src/machine.rs
+++ b/crates/stark/src/machine.rs
@@ -325,7 +325,7 @@ impl<SC: StarkGenericConfig, A: MachineAir<Val<SC>> + Air<SymbolicAirBuilder<Val
     /// The setup preprocessing phase.
     ///
     /// Given a program, this function generates the proving and verifying keys. The keys correspond
-    /// to the program code and other preprocessed colunms such as lookup tables.
+    /// to the program code and other preprocessed columns such as lookup tables.
     #[instrument("setup machine", level = "debug", skip_all)]
     #[allow(clippy::map_unwrap_or)]
     #[allow(clippy::redundant_closure_for_method_calls)]

--- a/docs/src/dev/guest-program.md
+++ b/docs/src/dev/guest-program.md
@@ -15,7 +15,7 @@ Note that type `T` must implement both `serde::Serialize` and `serde::Deserializ
 Ziren also provides Go runtime libraries for guest programs to handle input/output operations and exit operation:
 - `zkm_runtime.Read[T any]` (for reading structured data)
 - `zkm_runtime.Commit[T any]` (for committing structured data)
-- `zkm_runtime.RuntimeExit` (for exitting program)
+- `zkm_runtime.RuntimeExit` (for exiting program)
 
 ## Guest Program Example
 


### PR DESCRIPTION

## **Description:**

Fixed typo "colunms" → "columns"
Fixed typo "exitting" → "exiting"

