### PR TITLE
docs: fix typo

### DIFF
--- a/crates/recursion/circuit/src/machine/compress.rs
+++ b/crates/recursion/circuit/src/machine/compress.rs
@@ -198,7 +198,7 @@ where
                     *digest = first_digest;
                 }
 
-                // Initiallize start pc.
+                // Initialize start pc.
                 compress_public_values.start_pc = current_public_values.start_pc;
                 pc = current_public_values.start_pc;
 

--- a/examples/json/lib/src/lib.rs
+++ b/examples/json/lib/src/lib.rs
@@ -1,4 +1,4 @@
-// Custom structs with seralize/deserialize.
+// Custom structs with serialize/deserialize.
 
 use serde::{Deserialize, Serialize};
 


### PR DESCRIPTION
`Initiallize` corrected to `Initialize`
`seralize` corrected to `serialize`