### PR TITLE
feat: implement add_byte_lookup_events_from_maps for Vec<ByteLookupEv…

### DIFF
--- a/crates/core/executor/src/events/byte.rs
+++ b/crates/core/executor/src/events/byte.rs
@@ -122,9 +122,15 @@ impl ByteRecord for Vec<ByteLookupEvent> {
 
     fn add_byte_lookup_events_from_maps(
         &mut self,
-        _new_events: Vec<&HashMap<ByteLookupEvent, usize>>,
+        new_events: Vec<&HashMap<ByteLookupEvent, usize>>,
     ) {
-        todo!()
+        for new_blu_map in new_events {
+            for (blu_event, count) in new_blu_map.iter() {
+                for _ in 0..*count {
+                    self.push(*blu_event);
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
Implements the missing `add_byte_lookup_events_from_maps` method for `Vec<ByteLookupEvent>` in the `ByteRecord` trait implementation.

## Changes
- **File:** `crates/core/executor/src/events/byte.rs`
- **Lines:** 123-134
- **Change:** Replaced `todo!()` with proper implementation
