### PR TITLE
docs: fixed dead link

### DIFF
--- a/docs/src/dev/guest-program.md
+++ b/docs/src/dev/guest-program.md
@@ -64,8 +64,7 @@ pub fn main() {
 }
 ```
 
-### Go Example: [Simple-Go]
-(https://github.com/ProjectZKM/Ziren/blob/main/examples/simple-go/guest/main.go)
+### Go Example: [Simple-Go](https://github.com/ProjectZKM/Ziren/blob/main/examples/simple-go/guest/main.go)
 
 ```go
 //! A simple program that takes a number `n` as input, and writes the `n`

--- a/docs/src/dev/guest-program.md
+++ b/docs/src/dev/guest-program.md
@@ -92,7 +92,7 @@ func main() {
 
 ### C/C++ Example: [Fibonacci_C](https://github.com/ProjectZKM/Ziren/blob/main/examples/fibonacci_c_lib/guest/src/main.rs)
 
-For non-Rust languages, you can compile them to static libraries and link them in Rust by FFI. For [example](https://github.com/ProjectZKM/Ziren/blob/main/examples/fibonacci_c_lib/lib/add.cpp):
+For non-Rust languages, you can compile them to static libraries and link them in Rust by FFI. For [example](https://github.com/ProjectZKM/Ziren/blob/main/examples/fibonacci_c_lib/guest/src/c_lib/add.cpp):
 
 ```C
 extern "C" {


### PR DESCRIPTION
Hi! I found dead link in docs and fixed their.

https://docs.zkm.io/dev/guest-program.html
<img width="1371" height="507" alt="image" src="https://github.com/user-attachments/assets/eb4f1b49-c324-48d7-ace8-c3d09bbb5408" />
