### PR TITLE
docs: typo in function name

### DIFF
--- a/crates/recursion/circuit/src/hash.rs
+++ b/crates/recursion/circuit/src/hash.rs
@@ -28,7 +28,7 @@ pub trait FieldHasher<F: Field> {
     fn constant_compress(input: [Self::Digest; 2]) -> Self::Digest;
 }
 
-pub trait Posedion2KoalaBearHasherVariable<C: CircuitConfig> {
+pub trait Poseidon2KoalaBearHasherVariable<C: CircuitConfig> {
     fn poseidon2_permute(
         builder: &mut Builder<C>,
         state: [Felt<C::F>; PERMUTATION_WIDTH],
@@ -80,7 +80,7 @@ impl FieldHasher<KoalaBear> for KoalaBearPoseidon2 {
     }
 }
 
-impl<C: CircuitConfig<F = KoalaBear>> Posedion2KoalaBearHasherVariable<C> for KoalaBearPoseidon2 {
+impl<C: CircuitConfig<F = KoalaBear>> Poseidon2KoalaBearHasherVariable<C> for KoalaBearPoseidon2 {
     fn poseidon2_permute(
         builder: &mut Builder<C>,
         input: [Felt<<C>::F>; PERMUTATION_WIDTH],
@@ -89,7 +89,7 @@ impl<C: CircuitConfig<F = KoalaBear>> Posedion2KoalaBearHasherVariable<C> for Ko
     }
 }
 
-impl<C: CircuitConfig> Posedion2KoalaBearHasherVariable<C> for KoalaBearPoseidon2Outer {
+impl<C: CircuitConfig> Poseidon2KoalaBearHasherVariable<C> for KoalaBearPoseidon2Outer {
     fn poseidon2_permute(
         builder: &mut Builder<C>,
         state: [Felt<<C>::F>; PERMUTATION_WIDTH],
@@ -106,7 +106,7 @@ impl<C: CircuitConfig<F = KoalaBear, Bit = Felt<KoalaBear>>> FieldHasherVariable
     type DigestVariable = [Felt<KoalaBear>; DIGEST_SIZE];
 
     fn hash(builder: &mut Builder<C>, input: &[Felt<<C as Config>::F>]) -> Self::DigestVariable {
-        <Self as Posedion2KoalaBearHasherVariable<C>>::poseidon2_hash(builder, input)
+        <Self as Poseidon2KoalaBearHasherVariable<C>>::poseidon2_hash(builder, input)
     }
 
     fn compress(

--- a/crates/recursion/circuit/src/lib.rs
+++ b/crates/recursion/circuit/src/lib.rs
@@ -4,7 +4,7 @@ use challenger::{
     CanCopyChallenger, CanObserveVariable, DuplexChallengerVariable, FieldChallengerVariable,
     MultiField32ChallengerVariable, SpongeChallengerShape,
 };
-use hash::{FieldHasherVariable, Posedion2KoalaBearHasherVariable};
+use hash::{FieldHasherVariable, Poseidon2KoalaBearHasherVariable};
 use itertools::izip;
 use p3_bn254_fr::Bn254Fr;
 use p3_field::FieldAlgebra;
@@ -90,7 +90,7 @@ pub trait KoalaBearFriConfig:
 }
 
 pub trait KoalaBearFriConfigVariable<C: CircuitConfig<F = KoalaBear>>:
-    KoalaBearFriConfig + FieldHasherVariable<C> + Posedion2KoalaBearHasherVariable<C>
+    KoalaBearFriConfig + FieldHasherVariable<C> + Poseidon2KoalaBearHasherVariable<C>
 {
     type FriChallengerVariable: FieldChallengerVariable<C, <C as CircuitConfig>::Bit>
         + CanObserveVariable<C, <Self as FieldHasherVariable<C>>::DigestVariable>

--- a/crates/recursion/circuit/src/machine/public_values.rs
+++ b/crates/recursion/circuit/src/machine/public_values.rs
@@ -7,7 +7,7 @@ use zkm_recursion_core::{
 };
 use zkm_stark::{air::PV_DIGEST_NUM_WORDS, Word};
 
-use crate::{hash::Posedion2KoalaBearHasherVariable, CircuitConfig};
+use crate::{hash::Poseidon2KoalaBearHasherVariable, CircuitConfig};
 
 #[derive(Debug, Clone, Copy, Default, AlignedBorrow)]
 #[repr(C)]
@@ -21,7 +21,7 @@ pub(crate) fn assert_recursion_public_values_valid<C, H>(
     public_values: &RecursionPublicValues<Felt<C::F>>,
 ) where
     C: CircuitConfig,
-    H: Posedion2KoalaBearHasherVariable<C>,
+    H: Poseidon2KoalaBearHasherVariable<C>,
 {
     let digest = recursion_public_values_digest::<C, H>(builder, public_values);
     for (value, expected) in public_values.digest.iter().copied().zip_eq(digest) {
@@ -36,7 +36,7 @@ pub(crate) fn recursion_public_values_digest<C, H>(
 ) -> [Felt<C::F>; DIGEST_SIZE]
 where
     C: CircuitConfig,
-    H: Posedion2KoalaBearHasherVariable<C>,
+    H: Poseidon2KoalaBearHasherVariable<C>,
 {
     let pv_slice = public_values.as_array();
     H::poseidon2_hash(builder, &pv_slice[..NUM_PV_ELMS_TO_HASH])
@@ -48,7 +48,7 @@ pub(crate) fn assert_root_public_values_valid<C, H>(
     public_values: &RootPublicValues<Felt<C::F>>,
 ) where
     C: CircuitConfig,
-    H: Posedion2KoalaBearHasherVariable<C>,
+    H: Poseidon2KoalaBearHasherVariable<C>,
 {
     let expected_digest = root_public_values_digest::<C, H>(builder, &public_values.inner);
     for (value, expected) in public_values.inner.digest.iter().copied().zip_eq(expected_digest) {
@@ -63,7 +63,7 @@ pub(crate) fn root_public_values_digest<C, H>(
 ) -> [Felt<C::F>; DIGEST_SIZE]
 where
     C: CircuitConfig,
-    H: Posedion2KoalaBearHasherVariable<C>,
+    H: Poseidon2KoalaBearHasherVariable<C>,
 {
     let input = public_values
         .zkm_vk_digest


### PR DESCRIPTION
There was a typo "posedion", changed it to "poseidon" in all the codebase,

It seems like there's no place left with this typo anymore, therefore code should be working as it worked before