### PR TITLE
chore: fix typos in code comments

### DIFF
--- a/crates/prover/src/lib.rs
+++ b/crates/prover/src/lib.rs
@@ -122,7 +122,7 @@ pub type CompressAir<F> = RecursionAir<F, COMPRESS_DEGREE>;
 pub type ShrinkAir<F> = RecursionAir<F, SHRINK_DEGREE>;
 pub type WrapAir<F> = RecursionAir<F, WRAP_DEGREE>;
 
-/// A end-to-end prover implementation for the Ziren zkVM.
+/// An end-to-end prover implementation for the Ziren zkVM.
 pub struct ZKMProver<C: ZKMProverComponents = DefaultProverComponents> {
     /// The machine used for proving the core step.
     pub core_prover: C::CoreProver,

--- a/crates/stark/src/air/lookup.rs
+++ b/crates/stark/src/air/lookup.rs
@@ -1,6 +1,6 @@
 use crate::lookup::LookupKind;
 
-/// An Lookup is a cross-table lookup.
+/// A Lookup is a cross-table lookup.
 pub struct AirLookup<E> {
     /// The values of the Lookup.
     pub values: Vec<E>,

--- a/crates/stark/src/kb31_poseidon2.rs
+++ b/crates/stark/src/kb31_poseidon2.rs
@@ -306,7 +306,7 @@ pub mod koala_bear_poseidon2 {
         }
     }
 
-    /// Implement serialization manually instead of using serde to avoid cloing the config.
+    /// Implement serialization manually instead of using serde to avoid cloning the config.
     impl Serialize for KoalaBearPoseidon2 {
         fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where

--- a/crates/stark/src/permutation.rs
+++ b/crates/stark/src/permutation.rs
@@ -266,7 +266,7 @@ pub fn eval_permutation_constraints<'a, F, AB>(
         // trace except the last column.
         for (entry, chunk) in perm_local[0..perm_local.len() - 1].iter().zip(lookup_chunks) {
             // First, we calculate the random linear combinations and multiplicities with the correct
-            // sign depending on wetther the lookup is a send or a receive.
+            // sign depending on whether the lookup is a send or a receive.
             let mut rlcs: Vec<AB::ExprEF> = Vec::with_capacity(batch_size);
             let mut multiplicities: Vec<AB::Expr> = Vec::with_capacity(batch_size);
             for (lookup, is_send) in chunk {


### PR DESCRIPTION
fixed some typos across comments