### PR TITLE
chore: fix reference in comment

### DIFF
--- a/crates/core/machine/src/air/memory.rs
+++ b/crates/core/machine/src/air/memory.rs
@@ -137,7 +137,7 @@ pub trait MemoryAirBuilder: BaseAirBuilder {
     ///
     /// This method verifies that the inputted is less than 2^24 by doing a 16 bit and 8 bit range
     /// check on it's limbs.  It will also verify that the limbs are correct.  This method is needed
-    /// since the memory access timestamp check (see [Self::verify_mem_access_ts]) needs to assume
+    /// since the memory access timestamp check (see [Self::eval_memory_access_timestamp]) needs to assume
     /// the clk is within 24 bits.
     fn eval_range_check_24bits(
         &mut self,


### PR DESCRIPTION
there’s no method named verify_mem_access_ts in this module, and the 24‑bit assumption is enforced by eval_memory_access_timestamp