### PR TITLE
Fix typos in comments and error messages

### DIFF
--- a/crates/core/machine/src/memory/instructions/air.rs
+++ b/crates/core/machine/src/memory/instructions/air.rs
@@ -243,7 +243,7 @@ impl MemoryInstructionsChip {
             local.mem_value_is_neg,
         );
 
-        // When the memory value is not negtive, assert that op_a value is
+        // When the memory value is not negative, assert that op_a value is
         // equal to the unsigned memory value.
         let mem_value_is_pos = (local.is_lb + local.is_lh - local.mem_value_is_neg)
             + local.is_lbu

--- a/crates/go-runtime/zkvm_runtime/deserialize.go
+++ b/crates/go-runtime/zkvm_runtime/deserialize.go
@@ -89,7 +89,7 @@ func deserializeData(data []byte, v reflect.Value, index int) (int, error) {
 			v.SetBytes(bytes)
 			return index + int(length), nil
 		}
-		return index, fmt.Errorf("unsupport type: %v, elem: %v", v.Kind(), v.Elem().Kind())
+		return index, fmt.Errorf("unsupported type: %v, elem: %v", v.Kind(), v.Elem().Kind())
 	case reflect.Array:
 		for i := 0; i < v.Len(); i++ {
 			var err error
@@ -126,5 +126,5 @@ func deserializeData(data []byte, v reflect.Value, index int) (int, error) {
 		}
 		return index, nil
 	}
-	return index, fmt.Errorf("unsupport type: %v", v.Kind())
+	return index, fmt.Errorf("unsupported type: %v", v.Kind())
 }

--- a/crates/go-runtime/zkvm_runtime/serialize.go
+++ b/crates/go-runtime/zkvm_runtime/serialize.go
@@ -80,7 +80,7 @@ func serializeData(v reflect.Value) ([]byte, error) {
 			}
 			return b, nil
 		}
-		return nil, fmt.Errorf("unsupport type: %v, elem: %v", v.Kind(), v.Elem().Kind())
+		return nil, fmt.Errorf("unsupported type: %v, elem: %v", v.Kind(), v.Elem().Kind())
 	case reflect.String:
 		b := make([]byte, 8+len(v.String()))
 		binary.LittleEndian.PutUint64(b, uint64(len(v.String())))
@@ -110,5 +110,5 @@ func serializeData(v reflect.Value) ([]byte, error) {
 		}
 		return data, nil
 	}
-	return nil, fmt.Errorf("unsupport type: %v", v.Kind())
+	return nil, fmt.Errorf("unsupported type: %v", v.Kind())
 }

--- a/docs/src/mips-vm/mips-vm.md
+++ b/docs/src/mips-vm/mips-vm.md
@@ -46,7 +46,7 @@ Two kinds of allocators are provided to rust guest program
 |   .bss	    |            |.bss size         |     ro      |   toolchain   |
 | Heap (contains program I/O) |	_end | 0x7f000000 - _end | rw | runtime     | 
 
- - embeded allocator： Program I/O address space is reserved and split from heap address space. A [TLS heap](https://github.com/rust-embedded/embedded-alloc) is used for heap management.
+ - embedded allocator： Program I/O address space is reserved and split from heap address space. A [TLS heap](https://github.com/rust-embedded/embedded-alloc) is used for heap management.
 
 |   Section	  |    Start	 |     Size	        |   Access		| Controlled-by |	
 | ----------- | ---------- | ---------------- | ----------- | ------------- |
@@ -61,7 +61,7 @@ Two kinds of allocators are provided to rust guest program
 | Heap        |	_end       | 0x3f000000 - _end | rw         |    runtime    | 
 
 ### Go guest program
-Go guest program is similar to embeded-mode rust guest program, except that the initial args is set by VM at the top of the stack. The memory layout is as follows:
+Go guest program is similar to embedded-mode rust guest program, except that the initial args is set by VM at the top of the stack. The memory layout is as follows:
 
 |   Section	  |    Start	 |     Size	        |   Access		| Controlled-by |	
 | ----------- | ---------- | ---------------- | ----------- | ------------- |


### PR DESCRIPTION
 Corrects spelling errors across codebase:

  - `negtive` → `negative` in memory instruction comments
  - `unsupport` → `unsupported` in Go runtime error messages (4 instances)
  - `embeded` → `embedded` in MIPS VM documentation (2 instances)