### PR TITLE
 docs: fix typos and grammar errors

### DIFF
--- a/crates/build/README.md
+++ b/crates/build/README.md
@@ -1,5 +1,5 @@
 # zkm-build
-Lightweight crate used to build a Ziren programs.
+Lightweight crate used to build Ziren programs.
 
 Exposes `build_program`, which builds a Ziren program in the local environment or in a docker container with the specified parameters from `BuildArgs`.
 

--- a/crates/core/machine/src/syscall/precompiles/README.md
+++ b/crates/core/machine/src/syscall/precompiles/README.md
@@ -95,7 +95,7 @@ op.
 
 #### Add a new field for your chip's events
 
-In the `PrecompileEvent` enum, add a new variant for you precompile op.
+In the `PrecompileEvent` enum, add a new variant for your precompile op.
 
 ```rust
 #[derive(Clone, Debug, Serialize, Deserialize, EnumIter)]

--- a/docs/src/design/design.md
+++ b/docs/src/design/design.md
@@ -1,7 +1,7 @@
 # Design
 
 
-As ​MIPS instruction set based zkVM, Ziren is designed to generate efficient zero-knowledge proofs for complex computations (e.g., smart contract execution). Its architecture integrates a ​modular state machine, ​custom chip design, and a ​hybrid proof system (STARK + SNARK). 
+As a MIPS instruction set based zkVM, Ziren is designed to generate efficient zero-knowledge proofs for complex computations (e.g., smart contract execution). Its architecture integrates a ​modular state machine, ​custom chip design, and a ​hybrid proof system (STARK + SNARK). 
 
 - Modular State Machine
 

--- a/docs/src/design/memory-checking.md
+++ b/docs/src/design/memory-checking.md
@@ -1,6 +1,6 @@
 # Memory Consistency Checking
 
-[Offline memory checking](https://georgwiese.github.io/crypto-summaries/Concepts/Protocols/Offline-Memory-Checking) is a method that enables a prover to demonstrate to a verifier that a read/write memory was used correctly. In such a memory system, a value \\(v\\) can be written to an addresses \\(a\\) and subsequently retrieved. This technique allows the verifier to efficiently confirm that the prover adhered to the memory's rules (i.e., that the value returned by any read operation is indeed the most recent value that was written to that memory address).
+[Offline memory checking](https://georgwiese.github.io/crypto-summaries/Concepts/Protocols/Offline-Memory-Checking) is a method that enables a prover to demonstrate to a verifier that a read/write memory was used correctly. In such a memory system, a value \\(v\\) can be written to an address \\(a\\) and subsequently retrieved. This technique allows the verifier to efficiently confirm that the prover adhered to the memory's rules (i.e., that the value returned by any read operation is indeed the most recent value that was written to that memory address).
 
 This is in contrast to "online memory checking" techniques like Merkle hashing which ​immediately verify that a memory read was done correctly by insisting that each read includes an authentication path. Merkle hashing is  ​computationally expensive on a per-read basis for ZK provers, and offline memory checking suffices for zkVM design.
 

--- a/docs/src/dev/proof-aggregation.md
+++ b/docs/src/dev/proof-aggregation.md
@@ -4,7 +4,7 @@ With aggregation, multiple proofs can be combined together into a single aggrega
 
 In this example, multiple proofs proving the execution of a Fibonacci sequence for different values of `n` are combined into a single higher-level “aggregated” proof. This higher-level proof proves that the collection of all the other Fibonacci individual proofs are valid. 
 
-Instead of verifying each proof one by one, a verifier only needs to check a single aggregated proof. The batching  of many small computations into a single proof reduces verification costs and enables applications such as block aggregation, where many transactions in a block can be proven with one single succinct proof.  
+Instead of verifying each proof one by one, a verifier only needs to check a single aggregated proof. The batching of many small computations into a single proof reduces verification costs and enables applications such as block aggregation, where many transactions in a block can be proven with one single succinct proof.  
 
 The host generates individual proofs, the guest recursively verifies them, and the final output aggregated proof can be cheaply verified. 
 

--- a/docs/src/dev/verifier.md
+++ b/docs/src/dev/verifier.md
@@ -222,7 +222,7 @@ When deployed, the verifier logic is placed on Ethereum at a specific contract a
 
 The deployed contract points to the correct verifier implementation (e.g., `ZKMVerifierGroth16`), and users interact with it by calling the `verifyProof()` function.
 
-The prof lifecycle for EVM-based verification is as follows:
+The proof lifecycle for EVM-based verification is as follows:
 
 1. After proof generation, the proof bytes, verifying key, and public values are submitted in a transaction to the deployed verifier contract (e.g., `ZKMVerifierGroth16`).
 2. Full nodes execute the verifier contract, checking that the proof matches the verifying key, that the public values are consistent, and that all cryptographic constraints of the proof system hold.

--- a/docs/src/introduction/quickstart.md
+++ b/docs/src/introduction/quickstart.md
@@ -4,7 +4,7 @@ Get started with Ziren by executing, generating and verifying a proof for your c
 
 Overview of all the steps to create your Ziren proof: 
 
-1. Create a new project with using the Ziren project template or CLI
+1. Create a new project using the Ziren project template or CLI
 2. Compile and execute your guest program 
 3. Generate a ZK proof of your program locally or via the proving network 
 4. Verify the proof of your program, including on-chain verification  
@@ -102,7 +102,7 @@ contracts: contains the Solidity verifier smart contracts and test scripts for o
 - `contracts/src/Fibonacci.sol`: a sample Solidity contract demonstrating input/output structure for the Fibonacci program.
 - `IZKMVerifier.sol`: implemented Ziren interface for verifiers.
 - `fixtures/`: contains the public outputs, proof and verification keys in JSON format.
-- `v1.0.0/`: contains the Groth16 and PlONK verifier implementations and wrapper contracts.
+- `v1.0.0/`: contains the Groth16 and PLONK verifier implementations and wrapper contracts.
 - `contracts/script/`: contains forge scripts to deploy the verifier contracts.
 - `contracts/test/`: contains Foundry tests to validate verifier functionality.
 

--- a/docs/src/mips-vm/mips-isa.md
+++ b/docs/src/mips-vm/mips-isa.md
@@ -78,7 +78,7 @@ Instructions BEQ (branch if equal), BGEZ (branch if greater than or equal to zer
 Jump-related instructions, including Jump, Jumpi, and JumpDirect, are responsible for altering the execution flow by redirecting it to different parts of the program. They are used for implementing function calls, loops, and other control structures that require non-sequential execution, ensuring that the program can navigate its code dynamically.
 
 **Syscall Instructions**  
-SYSCALL triggers a system call, allowing the program to request services from the zkvm operating system. The service can be a precompiles computation, such as do sha extend operation by `SHA_EXTEND` precompile. it also can be input/output operation such as `SYSHINTREADYSHINTREAD` and `WRITE`.
+SYSCALL triggers a system call, allowing the program to request services from the zkvm operating system. The service can be a precompile computation, such as do sha extend operation by `SHA_EXTEND` precompile. it also can be input/output operation such as `SYSHINTREADYSHINTREAD` and `WRITE`.
 
 **Misc Instructions**  
 This category includes other instructions. TEQ is typically used to test equality conditions between registers. MADDU/MSUBU is used for multiply accumulation. SEB/SEH is for data sign extended. EXT/INS is for bits extraction and insertion.


### PR DESCRIPTION
Fixes 9 typos and grammar errors found in documentation:

  - Article errors: "a Ziren programs" → "Ziren programs", "an addresses" → "an address"
  - Misspellings: "prof lifecycle" → "proof lifecycle", "you precompile" → "your precompile"
  - Acronym: "PlONK" → "PLONK" (correct capitalization)
  - Formatting: removed double space in proof-aggregation.md