### PR TITLE
fix(cuda): correct Drop log type and cleanup_container doc grammar

### DIFF
--- a/crates/cuda/src/lib.rs
+++ b/crates/cuda/src/lib.rs
@@ -388,7 +388,7 @@ impl Drop for ZKMCudaProver {
     fn drop(&mut self) {
         if let Some(container) = &self.managed_container {
             if !container.cleaned_up.load(Ordering::SeqCst) {
-                tracing::debug!("dropping ZKMProverClient, cleaning up...");
+                tracing::debug!("Dropping ZKMCudaProver, cleaning up...");
                 cleanup_container(&container.name);
                 container.cleaned_up.store(true, Ordering::SeqCst);
             }
@@ -396,7 +396,7 @@ impl Drop for ZKMCudaProver {
     }
 }
 
-/// Cleans up the a docker container with the given name.
+/// Cleans up a Docker container with the given name.
 fn cleanup_container(container_name: &str) {
     if let Err(e) = Command::new("docker").args(["rm", "-f", container_name]).output() {
         eprintln!(


### PR DESCRIPTION
The drop-time log message incorrectly referenced ZKMProverClient, which could mislead readers and complicate tracing during resource cleanup; updating it to ZKMCudaProver aligns the message with the actual type and improves observability when diagnosing container lifecycle events. The cleanup_container documentation had a minor grammatical error and inconsistent capitalization, which reduces clarity for maintainers; fixing the grammar and proper Docker capitalization improves readability without changing behavior.