### PR TITLE
docs: fix grammatical issues

### DIFF
--- a/crates/core/machine/src/control_flow/branch/air.rs
+++ b/crates/core/machine/src/control_flow/branch/air.rs
@@ -20,7 +20,7 @@ use super::{BranchChip, BranchColumns};
 ///    boolean that indicates whether the branch condition is true.
 /// 2. It verifies the correct value of branching based on the helper bool columns (a_eq_b,
 ///    a_gt_b, a_lt_b).
-/// 3. It verifier the correct values of the helper bool columns based on op_a and op_b.
+/// 3. It verifies the correct values of the helper bool columns based on op_a and op_b.
 ///
 impl<AB> Air<AB> for BranchChip
 where

--- a/crates/curves/src/weierstrass/bls12_381.rs
+++ b/crates/curves/src/weierstrass/bls12_381.rs
@@ -66,7 +66,7 @@ impl EllipticCurveParameters for Bls12381Parameters {
 }
 
 impl WeierstrassParameters for Bls12381Parameters {
-    // The values of `A` and `B` has been taken from py_ecc python library by Ethereum Foundation.
+    // The values of `A` and `B` have been taken from py_ecc python library by Ethereum Foundation.
     // https://github.com/ethereum/py_ecc/blob/7b9e1b3/py_ecc/bls12_381/bls12_381_curve.py#L31
     const A: GenericArray<u8, U48> = GenericArray::from_array([
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,


### PR DESCRIPTION
it verifier -> it verifies
The values of `A` and `B` has -> The values of `A` and `B` have