### PR TITLE
chore: remove unused import from hash_to_field

### DIFF
--- a/crates/verifier/src/plonk/hash_to_field.rs
+++ b/crates/verifier/src/plonk/hash_to_field.rs
@@ -1,4 +1,3 @@
-use alloc::vec;
 use alloc::vec::Vec;
 use core::hash::Hasher;
 use sha2::Digest;


### PR DESCRIPTION
Remove the unused alloc::vec import from hash_to_field.rs to keep the module clean. The file only relies on alloc::vec::Vec, so having the extra import provides no benefit