### PR TITLE
fix: correct stateless prove_core doc reference

### DIFF
--- a/crates/cuda/src/lib.rs
+++ b/crates/cuda/src/lib.rs
@@ -315,7 +315,7 @@ impl ZKMCudaProver {
         Ok(proof)
     }
 
-    /// Executes the [zkm_prover::ZKMProver::prove_core] method inside the container.
+    /// Executes the [zkm_prover::ZKMProver::stateless_prove_core] method inside the container.
     ///
     /// You will need at least 24GB of VRAM to run this method.
     pub fn prove_core_stateless(


### PR DESCRIPTION
The doc comment on ZKMCudaProver::prove_core_stateless incorrectly referenced ZKMProver::prove_core, which is the stateful variant. This could mislead readers when distinguishing between stateful and stateless proving flows. The comment now points to ZKMProver::stateless_prove_core to accurately document the method’s behavior.