### PR TITLE
fix(sdk): remove unnecessary clone in zkm_dump

### DIFF
--- a/crates/sdk/src/utils.rs
+++ b/crates/sdk/src/utils.rs
@@ -15,7 +15,7 @@ pub(crate) fn zkm_dump(elf: &[u8], stdin: &ZKMStdin) {
     if std::env::var("ZKM_DUMP").map(|v| v == "1" || v.to_lowercase() == "true").unwrap_or(false) {
         std::fs::write("program.bin", elf).unwrap();
         let stdin = bincode::serialize(&stdin).unwrap();
-        std::fs::write("stdin.bin", stdin.clone()).unwrap();
+        std::fs::write("stdin.bin", &stdin).unwrap();
     }
 }
 


### PR DESCRIPTION
Avoid cloning the serialized stdin buffer before writing it to stdin.bin. fs::write only needs a &[u8], so reusing the existing Vec eliminates an unnecessary allocation and copy without changing the dump format or any observable behavior.