### PR TITLE
docs: clarify Shape::new constructor comment

### DIFF
--- a/crates/stark/src/shape/mod.rs
+++ b/crates/stark/src/shape/mod.rs
@@ -27,7 +27,7 @@ pub struct Shape<K: Clone + Eq + Hash> {
 }
 
 impl<K: Clone + Eq + Hash + FromStr> Shape<K> {
-    /// Create a new empty shape.
+    /// Create a new shape from an existing map of log2 heights.
     #[must_use]
     pub fn new(inner: HashMap<K, usize>) -> Self {
         Self { inner }


### PR DESCRIPTION
The previous doc comment claimed that Shape::new creates an empty shape, while the function actually wraps a provided HashMap<K, usize> of log2 heights. This wording was misleading for callers and inconsistent with the existing Default implementation and with ShapeCluster::new. The comment is updated to describe the real behavior, so the API documentation now accurately reflects how shapes are constructed.