### PR TITLE
refactor: remove redundant observe_slice override

### DIFF
--- a/crates/recursion/circuit/src/challenger.rs
+++ b/crates/recursion/circuit/src/challenger.rs
@@ -159,16 +159,6 @@ impl<C: Config<F = KoalaBear>> CanObserveVariable<C, Felt<C::F>> for DuplexChall
     fn observe(&mut self, builder: &mut Builder<C>, value: Felt<C::F>) {
         DuplexChallengerVariable::observe(self, builder, value);
     }
-
-    fn observe_slice(
-        &mut self,
-        builder: &mut Builder<C>,
-        values: impl IntoIterator<Item = Felt<C::F>>,
-    ) {
-        for value in values {
-            self.observe(builder, value);
-        }
-    }
 }
 
 impl<C: Config<F = KoalaBear>, const N: usize> CanObserveVariable<C, [Felt<C::F>; N]>


### PR DESCRIPTION
The DuplexChallengerVariable implementation of CanObserveVariable<Felt<_>> was manually overriding observe_slice with the same logic as the default method in the trait. This override did not change behavior or performance, but duplicated code and diverged from the pattern used by other CanObserveVariable implementations. By relying on the trait's provided observe_slice, we keep the challenger API simpler and avoid maintaining duplicated logic without introducing any functional changes.