### PR TITLE
fix: correct AffinePoint::to_le_bytes doc comment

### DIFF
--- a/crates/zkvm/lib/src/utils.rs
+++ b/crates/zkvm/lib/src/utils.rs
@@ -44,7 +44,7 @@ pub trait AffinePoint<const N: usize>: Clone + Sized {
         Self::new(limbs.try_into().unwrap())
     }
 
-    /// Creates a new [`AffinePoint`] from the given bytes in big endian.
+    /// Returns the little-endian byte representation of this [`AffinePoint`].
     fn to_le_bytes(&self) -> Vec<u8> {
         let le_bytes = words_to_bytes_le(self.limbs_ref());
         debug_assert!(le_bytes.len() == N * 4);


### PR DESCRIPTION
The previous doc comment for AffinePoint::to_le_bytes claimed it created a new point from big-endian bytes, which is the opposite of what the method actually does. The method serializes the point to little-endian bytes via words_to_bytes_le. This change updates the comment to describe the little-endian byte representation accurately and avoid confusion with 
from_le_bytes and related callers.