### PR TITLE
fix: avoid cloning proof_stream entry in verify syscall

### DIFF
--- a/crates/core/executor/src/syscalls/verify.rs
+++ b/crates/core/executor/src/syscalls/verify.rs
@@ -38,13 +38,13 @@ impl Syscall for VerifySyscall {
             if proof_index >= rt.state.proof_stream.len() {
                 panic!("Not enough proofs were written to the runtime.");
             }
-            let (proof, proof_vk) = &rt.state.proof_stream[proof_index].clone();
             rt.state.proof_stream_ptr += 1;
 
             let vkey_bytes: [u32; 8] = vkey.try_into().unwrap();
             let pv_digest_bytes: [u32; 8] = pv_digest.try_into().unwrap();
 
             if let Some(verifier) = rt.subproof_verifier {
+                let (proof, proof_vk) = &rt.state.proof_stream[proof_index];
                 if let Err(e) =
                     verifier.verify_deferred_proof(proof, proof_vk, vkey_bytes, pv_digest_bytes)
                 {


### PR DESCRIPTION
Avoid cloning the proof_stream entry in the verify syscall and instead borrow it directly. The proof_stream_ptr is now incremented before borrowing, and the element is only accessed when a SubproofVerifier is present. This removes an unnecessary clone of a potentially heavy proof and verifying key, avoids extra allocations and work when no verifier is configured, and preserves the original runtime semantics of advancing the proof_stream pointer.