### PR TITLE
fix: correct bn254 fp and fp2 chip comments

### DIFF
--- a/crates/core/executor/src/air.rs
+++ b/crates/core/executor/src/air.rs
@@ -63,9 +63,9 @@ pub enum MipsAirId {
     Bls12831Fp2AddSubAssign = 20,
     /// The bls12-831 fp2 mul assign chip.
     Bls12831Fp2MulAssign = 21,
-    /// The bn254 fp2 add sub assign chip.
-    Bn254FpOpAssign = 22,
     /// The bn254 fp op assign chip.
+    Bn254FpOpAssign = 22,
+    /// The bn254 fp2 add sub assign chip.
     Bn254Fp2AddSubAssign = 23,
     /// The bn254 fp2 mul assign chip.
     Bn254Fp2MulAssign = 24,


### PR DESCRIPTION
The comments for Bn254FpOpAssign and Bn254Fp2AddSubAssign were swapped, describing fp operations as fp2 add/sub and vice versa. This was confusing for anyone reading or searching by the documentation and could lead to misuse of these variants based on the wrong description. The change realigns the comments with the actual meaning of the enum variants without touching any functional code.