### PR TITLE
perf: avoid heap allocation in g1_to_bytes

### DIFF
--- a/crates/verifier/src/plonk/converter.rs
+++ b/crates/verifier/src/plonk/converter.rs
@@ -173,9 +173,9 @@ pub(crate) fn load_plonk_proof_from_bytes(
     Ok(result)
 }
 
-pub(crate) fn g1_to_bytes(g1: &AffineG1) -> Result<Vec<u8>, PlonkError> {
+pub(crate) fn g1_to_bytes(g1: &AffineG1) -> Result<[u8; 64], PlonkError> {
     let mut bytes: [u8; 64] = unsafe { core::mem::transmute(*g1) };
     bytes[..32].reverse();
     bytes[32..].reverse();
-    Ok(bytes.to_vec())
+    Ok(bytes)
 }


### PR DESCRIPTION
This change updates plonk::converter::g1_to_bytes to return a fixed-size [u8; 64] array instead of allocating a Vec<u8>. All existing call sites only ever use the result as &[u8], so the API remains compatible while removing a redundant heap allocation per call. The serialization layout and use of unsafe are left unchanged; only the extra to_vec() and its allocation are eliminated to reduce overhead in the PLONK verification hot path.