### PR TITLE
fix(stark): correct logup_batch_size doc comment

### DIFF
--- a/crates/stark/src/chip.rs
+++ b/crates/stark/src/chip.rs
@@ -168,7 +168,7 @@ where
         1 << self.log_quotient_degree
     }
 
-    /// Returns the log2 of the batch size.
+    /// Returns the batch size.
     #[inline]
     pub const fn logup_batch_size(&self) -> usize {
         1 << self.log_quotient_degree


### PR DESCRIPTION
Updated the doc comment for logup_batch_size to state that it returns the batch size instead of its logarithm. The previous wording suggested it returned log2 of the batch size, which does not match the implementation and could mislead callers of the API.