### PR TITLE
chore(primitives): deprecate Buffer::head

### DIFF
--- a/crates/primitives/src/types.rs
+++ b/crates/primitives/src/types.rs
@@ -26,7 +26,10 @@ impl Buffer {
         Self { data: data.to_vec(), ptr: 0 }
     }
 
-    /// Set the position ptr to the beginning of the buffer.                                      
+    /// Set the position ptr to the beginning of the buffer.                                              
+    #[deprecated(
+        note = "Unused in the current codebase and scheduled for removal in a future release."
+    )]
     pub fn head(&mut self) {
         self.ptr = 0;
     }


### PR DESCRIPTION
`Buffer::head` is not used anywhere in the current codebase and is not part of any documented workflow. Marking it as deprecated keeps the public API technically intact while signalling that the method will be removed in a future release, reducing dead API surface without breaking existing users immediately.