### PR TITLE
docs: fix BaseAluInstr doc comment

### DIFF
--- a/crates/recursion/core/src/lib.rs
+++ b/crates/recursion/core/src/lib.rs
@@ -59,7 +59,7 @@ pub struct BaseAluIo<V> {
 
 pub type BaseAluEvent<F> = BaseAluIo<F>;
 
-/// An instruction invoking the extension field ALU.
+/// An instruction invoking the base field ALU.
 #[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 #[repr(C)]
 pub struct BaseAluInstr<F> {


### PR DESCRIPTION
The doc comment for BaseAluInstr incorrectly stated that it invokes the extension field ALU, while the type is used for the base field ALU. This change updates the comment to match the actual semantics so that readers and maintainers are not misled when working with the ALU instruction types.