### PR TITLE
fix: correct permutation constraint count comment

### DIFF
--- a/crates/stark/src/permutation.rs
+++ b/crates/stark/src/permutation.rs
@@ -373,8 +373,9 @@ pub fn count_permutation_constraints<F: Field>(
         count += local_permutation_width - 1;
 
         // One assert that cumulative sum is initialized to `phi_local` on the first row.
-        // Two asserts that the cumulative sum is constrained to `phi_next - phi_local` on the transition
+        // One assert that the cumulative sum is constrained to `phi_next - phi_local` on the transition
         // rows.
+        // One assert that the cumulative sum on the last row matches `local_cumulative_sum`.
         count += 3;
     }
 


### PR DESCRIPTION
The comment in count_permutation_constraints claimed there were two transition constraints on the cumulative sum, while eval_permutation_constraints actually uses one transition constraint plus a final-row check against local_cumulative_sum. The implementation and the numeric counter were already consistent; only the comment was misleading. This change updates the comment to accurately describe the three cumulative sum constraints without altering behavior.