### PR TITLE
Refactor ProverClient::execute to borrow stdin

### DIFF
--- a/crates/sdk/src/action.rs
+++ b/crates/sdk/src/action.rs
@@ -15,7 +15,7 @@ pub struct Execute<'a> {
     prover: &'a dyn Prover<DefaultProverComponents>,
     context_builder: ZKMContextBuilder<'a>,
     elf: &'a [u8],
-    stdin: ZKMStdin,
+    stdin: &'a ZKMStdin,
 }
 
 impl<'a> Execute<'a> {
@@ -26,7 +26,7 @@ impl<'a> Execute<'a> {
     pub fn new(
         prover: &'a dyn Prover<DefaultProverComponents>,
         elf: &'a [u8],
-        stdin: ZKMStdin,
+        stdin: &'a ZKMStdin,
     ) -> Self {
         Self { prover, elf, stdin, context_builder: Default::default() }
     }
@@ -35,7 +35,7 @@ impl<'a> Execute<'a> {
     pub fn run(self) -> Result<(ZKMPublicValues, ExecutionReport)> {
         let Self { prover, elf, stdin, mut context_builder } = self;
         let context = context_builder.build();
-        Ok(prover.zkm_prover().execute(elf, &stdin, context)?)
+        Ok(prover.zkm_prover().execute(elf, stdin, context)?)
     }
 
     /// Add a runtime [Hook](super::Hook) into the context.

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -199,9 +199,9 @@ impl ProverClient {
     /// stdin.write(&10usize);
     ///
     /// // Execute the program on the inputs.
-    /// let (public_values, report) = client.execute(elf, stdin).run().unwrap();
+    /// let (public_values, report) = client.execute(elf, &stdin).run().unwrap();
     /// ```
-    pub fn execute<'a>(&'a self, elf: &'a [u8], stdin: ZKMStdin) -> action::Execute<'a> {
+    pub fn execute<'a>(&'a self, elf: &'a [u8], stdin: &'a ZKMStdin) -> action::Execute<'a> {
         action::Execute::new(self.prover.as_ref(), elf, stdin)
     }
 
@@ -397,7 +397,7 @@ mod tests {
         let elf = test_artifacts::FIBONACCI_ELF;
         let mut stdin = ZKMStdin::new();
         stdin.write(&10usize);
-        let (_, _report) = client.execute(elf, stdin).run().unwrap();
+        let (_, _report) = client.execute(elf, &stdin).run().unwrap();
         // tracing::info!("gas = {}", report.estimate_gas());
     }
 
@@ -409,7 +409,7 @@ mod tests {
         let elf = test_artifacts::PANIC_ELF;
         let mut stdin = ZKMStdin::new();
         stdin.write(&10usize);
-        client.execute(elf, stdin).run().unwrap();
+        client.execute(elf, &stdin).run().unwrap();
     }
 
     #[should_panic]
@@ -420,7 +420,7 @@ mod tests {
         let elf = test_artifacts::PANIC_ELF;
         let mut stdin = ZKMStdin::new();
         stdin.write(&10usize);
-        client.execute(elf, stdin).max_cycles(1).run().unwrap();
+        client.execute(elf, &stdin).max_cycles(1).run().unwrap();
     }
 
     #[test]

--- a/examples/bitcoin/host/src/main.rs
+++ b/examples/bitcoin/host/src/main.rs
@@ -17,7 +17,7 @@ fn main() {
     let (pk, vk) = client.setup(BTC_ELF);
 
     // Execute the guest using the `ProverClient.execute` method, without generating a proof.
-    let (_, report) = client.execute(BTC_ELF, stdin.clone()).run().unwrap();
+    let (_, report) = client.execute(BTC_ELF, &stdin).run().unwrap();
     println!("executed program with {} cycles", report.total_instruction_count());
 
     let proof = client.prove(&pk, stdin).run().expect("proving failed");

--- a/examples/fibonacci/host/src/main.rs
+++ b/examples/fibonacci/host/src/main.rs
@@ -19,7 +19,7 @@ fn main() {
     let client = ProverClient::new();
 
     // Execute the guest using the `ProverClient.execute` method, without generating a proof.
-    let (_, report) = client.execute(ELF, stdin.clone()).run().unwrap();
+    let (_, report) = client.execute(ELF, &stdin).run().unwrap();
     println!("executed program with {} cycles", report.total_instruction_count());
 
     // Generate the proof for the given guest and input.

--- a/examples/fibonacci_c_lib/host/src/main.rs
+++ b/examples/fibonacci_c_lib/host/src/main.rs
@@ -19,7 +19,7 @@ fn main() {
     let client = ProverClient::new();
 
     // Execute the guest using the `ProverClient.execute` method, without generating a proof.
-    let (_, report) = client.execute(ELF, stdin.clone()).run().unwrap();
+    let (_, report) = client.execute(ELF, &stdin).run().unwrap();
     println!("executed program with {} cycles", report.total_instruction_count());
 
     // Generate the proof for the given guest and input.

--- a/examples/keccak-precompile/host/src/main.rs
+++ b/examples/keccak-precompile/host/src/main.rs
@@ -27,7 +27,7 @@ fn prove_keccak_rust() {
     let client = ProverClient::new();
 
     // Execute the program using the `ProverClient.execute` method, without generating a proof.
-    let (_, report) = client.execute(ELF, stdin.clone()).run().unwrap();
+    let (_, report) = client.execute(ELF, &stdin).run().unwrap();
     println!("executed program with {} cycles", report.total_instruction_count());
 
     // Generate the proof for the given program and input.

--- a/examples/large-sum/host/src/main.rs
+++ b/examples/large-sum/host/src/main.rs
@@ -22,7 +22,7 @@ fn main() {
     let client = ProverClient::new();
 
     // Execute the guest using the `ProverClient.execute` method, without generating a proof.
-    let (_, report) = client.execute(ELF, stdin.clone()).run().unwrap();
+    let (_, report) = client.execute(ELF, &stdin).run().unwrap();
     println!("executed program with {} cycles", report.total_instruction_count());
 
     // Generate the proof for the given guest and input.

--- a/examples/poseidon2/host/src/main.rs
+++ b/examples/poseidon2/host/src/main.rs
@@ -17,7 +17,7 @@ fn main() {
     let client = ProverClient::new();
 
     // Execute the guest using the `ProverClient.execute` method, without generating a proof.
-    let (_, report) = client.execute(ELF, stdin.clone()).run().unwrap();
+    let (_, report) = client.execute(ELF, &stdin).run().unwrap();
     println!("executed program with {} cycles", report.total_instruction_count());
 
     // Generate the proof for the given guest and input.

--- a/examples/rsa/host/src/main.rs
+++ b/examples/rsa/host/src/main.rs
@@ -55,7 +55,7 @@ fn main() {
     let (pk, vk) = client.setup(RSA_ELF);
 
     // Execute the guest using the `ProverClient.execute` method, without generating a proof.
-    let (_, report) = client.execute(RSA_ELF, stdin.clone()).run().unwrap();
+    let (_, report) = client.execute(RSA_ELF, &stdin).run().unwrap();
     println!("executed program with {} cycles", report.total_instruction_count());
 
     let proof = client.prove(&pk, stdin).run().expect("proving failed");

--- a/examples/simple-go/host/src/main.rs
+++ b/examples/simple-go/host/src/main.rs
@@ -15,7 +15,7 @@ fn prove_simple_go() {
     let client = ProverClient::new();
 
     // Execute the guest using the `ProverClient.execute` method, without generating a proof.
-    let (_, report) = client.execute(ELF, stdin.clone()).run().unwrap();
+    let (_, report) = client.execute(ELF, &stdin).run().unwrap();
     println!("executed program with {} cycles", report.total_instruction_count());
 
     // Generate the proof for the given guest and input.

--- a/examples/ssz-withdrawals/host/src/main.rs
+++ b/examples/ssz-withdrawals/host/src/main.rs
@@ -12,7 +12,7 @@ fn main() {
     let (pk, vk) = client.setup(ELF);
 
     // Execute the guest using the `ProverClient.execute` method, without generating a proof.
-    let (_, report) = client.execute(ELF, stdin.clone()).run().unwrap();
+    let (_, report) = client.execute(ELF, &stdin).run().unwrap();
     println!("executed program with {} cycles", report.total_instruction_count());
 
     let proof = client.prove(&pk, stdin).run().expect("proving failed");

--- a/examples/tendermint/host/src/main.rs
+++ b/examples/tendermint/host/src/main.rs
@@ -44,7 +44,7 @@ pub fn main() {
     let client = ProverClient::new();
     let (pk, vk) = client.setup(TENDERMINT_ELF);
 
-    let (_, report) = client.execute(TENDERMINT_ELF, stdin.clone()).run().unwrap();
+    let (_, report) = client.execute(TENDERMINT_ELF, &stdin).run().unwrap();
     println!("executed program with {} cycles", report.total_instruction_count());
 
     let proof = client.prove(&pk, stdin).run().expect("proving failed");

--- a/examples/unconstrained/host/src/main.rs
+++ b/examples/unconstrained/host/src/main.rs
@@ -8,7 +8,7 @@ fn main() {
 
     let client = ProverClient::new();
     let (public_values, report) =
-        client.execute(ELF, stdin.clone()).run().expect("failed to prove");
+        client.execute(ELF, &stdin).run().expect("failed to prove");
 
     println!("report: {}", report);
     println!("public_values: {:?}", public_values);


### PR DESCRIPTION
This PR changes `ProverClient::execute` to accept `&ZKMStdin` instead of consuming ownership.

**Rationale:**
In typical workflows, [execute](cci:1://file:///d:/friendly-project/Ziren/crates/sdk/src/provers/mod.rs:74:4-77:5) is often called alongside [prove](cci:1://file:///d:/friendly-project/Ziren/crates/sdk/src/lib.rs:207:4-238:5) for debugging or gas estimation. Since [prove](cci:1://file:///d:/friendly-project/Ziren/crates/sdk/src/lib.rs:207:4-238:5) also requires `stdin`, consuming ownership in [execute](cci:1://file:///d:/friendly-project/Ziren/crates/sdk/src/provers/mod.rs:74:4-77:5) forced users to unnecessarily `clone()` the input.

**Changes:**
- Updated the [Execute](cci:2://file:///d:/friendly-project/Ziren/crates/sdk/src/action.rs:13:0-18:1) builder to hold a reference to `ZKMStdin`.
- Refactored `ProverClient::execute` to take `&ZKMStdin`.
- Removed redundant `stdin.clone()` calls in examples and tests, eliminating unnecessary allocations.