### PR TITLE
fix: correct CompAluEvent constructor documentation

### DIFF
--- a/crates/core/executor/src/events/instr.rs
+++ b/crates/core/executor/src/events/instr.rs
@@ -72,7 +72,7 @@ pub struct CompAluEvent {
 }
 
 impl CompAluEvent {
-    /// Create a new [`AluEvent`].
+    /// Create a new [`CompAluEvent`].
     #[must_use]
     pub fn new(pc: u32, opcode: Opcode, a: u32, b: u32, c: u32) -> Self {
         Self {


### PR DESCRIPTION
The constructor documentation in the CompAluEvent impl incorrectly referenced AluEvent, which is misleading when reading the API or generated docs. This change updates the comment to reference CompAluEvent so the docs accurately describe which type is being constructed and avoid confusion for anyone navigating event structures in the executor.