### PR TITLE
fix: correct case reference in weierstrass_add_assign

### DIFF
--- a/crates/zkvm/lib/src/utils.rs
+++ b/crates/zkvm/lib/src/utils.rs
@@ -178,7 +178,7 @@ pub trait WeierstrassAffinePoint<const N: usize>: AffinePoint<N> {
 
         // Case 4: p1 is the negation of p2.
         // Note: If p1 and p2 are valid elliptic curve points, and p1.x == p2.x, that means that
-        // either p1.y == p2.y or p1.y + p2.y == p. Because we are past Case 4, we know that p1.y !=
+        // either p1.y == p2.y or p1.y + p2.y == p. Because we are past Case 3, we know that p1.y !=
         // p2.y, so we can just check if p1.x == p2.x. Therefore, this implicitly checks that
         // p1.x == p2.x AND p1.y + p2.y == p without modular negation.
         if p1[..N / 2] == p2[..N / 2] {


### PR DESCRIPTION
The comment in Case 4 said "Because we are past Case 4" which doesn't make sense - we're literally inside Case 4 at that point. Changed it to "Case 3" since that's the check we actually passed (p1 == p2) before reaching Case 4.