### PR TITLE
docs: align mov condition opcode names

### DIFF
--- a/docs/src/mips-vm/mips-isa.md
+++ b/docs/src/mips-vm/mips-isa.md
@@ -126,8 +126,8 @@ The support instructions are as follows:
 | LWR         | 100110     | base        | rt          | offset      | offset       | offset      | rt = rt merge least significant part of mem(base+offset)                               |
 | MFHI        | 000000     | 00000       | 00000       | rd          | 00000        | 010000      | rd = hi                                                      |
 | MFLO        | 000000     | 00000       | 00000       | rd          | 00000        | 010010      | rd = lo                                                      |
-| MOVN        | 000000     | rs          | rt          | rd          | 00000        | 001011      | rd = rs, if rt != 0                                          |
-| MOVZ        | 000000     | rs          | rt          | rd          | 00000        | 001010      | rd = rs, if rt == 0                                          |
+| MNE         | 000000     | rs          | rt          | rd          | 00000        | 001011      | rd = rs, if rt != 0                                          |
+| MEQ         | 000000     | rs          | rt          | rd          | 00000        | 001010      | rd = rs, if rt == 0                                          |
 | MTHI        | 000000     | rs          | 00000       | 00000       | 00000        | 010001      | hi = rs                                                      |
 | MTLO        | 000000     | rs          | 00000       | 00000       | 00000        | 010011      | lo = rs                                                      |
 | MUL         | 011100     | rs          | rt          | rd          | 00000        | 000010      | rd = rs * rt                                                 |


### PR DESCRIPTION
Renamed MOVZ/MOVN to MEQ/MNE in the ISA table so the documentation matches the actual opcode names used by the executor and mnemonic mapping.