### PR TITLE
fix(executor): remove incorrect sign extension for J/JAL target address

### DIFF
--- a/crates/core/executor/src/instruction.rs
+++ b/crates/core/executor/src/instruction.rs
@@ -319,7 +319,6 @@ impl Instruction {
         let offset = insn & 0xffff; // as known as imm
         let offset_ext16 = sign_extend::<16>(offset);
         let target = insn & 0x3ffffff;
-        let target_ext = sign_extend::<26>(target);
         log::trace!("op {opcode}, func {func}, rt {rt}, rs {rs}, rd {rd}");
         log::trace!("decode: insn {insn:X}, opcode {opcode:X}, func {func:X}");
 
@@ -440,14 +439,13 @@ impl Instruction {
                     Ok(Self::new_with_raw(Opcode::UNIMPL, 0, 0, insn, true, true, insn))
                 }
             }
-            // J
+            // J: target is unsigned (not sign-extended) per MIPS spec.
             (0x02, _) => {
-                // Ignore the upper 4 most significant bits，since they are always 0 currently.
-                Ok(Self::new(Opcode::Jumpi, 0u8, target_ext.overflowing_shl(2).0, 0, true, true))
+                Ok(Self::new(Opcode::Jumpi, 0u8, target << 2, 0, true, true))
             }
-            // JAL
+            // JAL: target is unsigned (not sign-extended) per MIPS spec.
             (0x03, _) => {
-                Ok(Self::new(Opcode::Jumpi, 31u8, target_ext.overflowing_shl(2).0, 0, true, true))
+                Ok(Self::new(Opcode::Jumpi, 31u8, target << 2, 0, true, true))
             }
             // BEQ
             (0x04, _) => Ok(Self::new(

--- a/crates/core/executor/src/instruction.rs
+++ b/crates/core/executor/src/instruction.rs
@@ -440,13 +440,9 @@ impl Instruction {
                 }
             }
             // J: target is unsigned (not sign-extended) per MIPS spec.
-            (0x02, _) => {
-                Ok(Self::new(Opcode::Jumpi, 0u8, target << 2, 0, true, true))
-            }
+            (0x02, _) => Ok(Self::new(Opcode::Jumpi, 0u8, target << 2, 0, true, true)),
             // JAL: target is unsigned (not sign-extended) per MIPS spec.
-            (0x03, _) => {
-                Ok(Self::new(Opcode::Jumpi, 31u8, target << 2, 0, true, true))
-            }
+            (0x03, _) => Ok(Self::new(Opcode::Jumpi, 31u8, target << 2, 0, true, true)),
             // BEQ
             (0x04, _) => Ok(Self::new(
                 Opcode::BEQ,


### PR DESCRIPTION
J and JAL instructions use a 26-bit unsigned address field. The code was applying sign_extend<26> which corrupted jump targets with bit 25 set (addresses >= 0x08000000 after shift). Removed sign extension per MIPS spec.