### PR TITLE
fix(memory): use MAX_MEMORY in heap limit panic

### DIFF
--- a/crates/zkvm/entrypoint/src/syscalls/memory.rs
+++ b/crates/zkvm/entrypoint/src/syscalls/memory.rs
@@ -43,7 +43,7 @@ pub unsafe extern "C" fn sys_alloc_aligned(bytes: usize, align: usize) -> *mut u
     let (heap_pos, overflowed) = heap_pos.overflowing_add(bytes);
 
     if overflowed || MAX_MEMORY < heap_pos {
-        panic!("Memory limit exceeded (0xC000000)");
+        panic!("Memory limit exceeded ({:#x})", MAX_MEMORY);
     }
 
     unsafe { HEAP_POS = heap_pos };

--- a/crates/zkvm/entrypoint/src/syscalls/memory.rs
+++ b/crates/zkvm/entrypoint/src/syscalls/memory.rs
@@ -43,7 +43,7 @@ pub unsafe extern "C" fn sys_alloc_aligned(bytes: usize, align: usize) -> *mut u
     let (heap_pos, overflowed) = heap_pos.overflowing_add(bytes);
 
     if overflowed || MAX_MEMORY < heap_pos {
-        panic!("Memory limit exceeded ({:#x})", MAX_MEMORY);
+        panic!("Memory limit exceeded ({MAX_MEMORY:#x})");
     }
 
     unsafe { HEAP_POS = heap_pos };


### PR DESCRIPTION
The panic message hardcoded an outdated limit that conflicted with MAX_MEMORY and project docs. Using the constant in the formatted message keeps diagnostics accurate and prevents future drift if the limit changes.