### PR TITLE
fix(curves): use ec_double for point doubling in scalar_mul

### DIFF
--- a/crates/curves/src/scalar_mul.rs
+++ b/crates/curves/src/scalar_mul.rs
@@ -15,7 +15,7 @@ impl<E: EllipticCurve> AffinePoint<E> {
             if bit {
                 result = result.map_or_else(|| Some(temp.clone()), |r| Some(&r + &temp));
             }
-            temp = &temp + &temp;
+            temp = E::ec_double(&temp);
         }
         result.expect("Scalar multiplication failed")
     }


### PR DESCRIPTION
Changed point doubling in scalar_mul from `&temp + &temp` to `ec_double(&temp)`. This is semantically correct since we're doubling a point, not adding two arbitrary points. Also makes the code safer if scalar_mul is ever used with Weierstrass curves where ec_add panics on equal points.