### PR TITLE
fix: incomplete SubAssign for SepticExtension

### DIFF
--- a/crates/stark/src/septic_extension.rs
+++ b/crates/stark/src/septic_extension.rs
@@ -282,6 +282,12 @@ impl<F: FieldAlgebra> Sub for SepticExtension<F> {
 impl<F: FieldAlgebra> SubAssign for SepticExtension<F> {
     fn sub_assign(&mut self, rhs: Self) {
         self.0[0] -= rhs.0[0].clone();
+        self.0[1] -= rhs.0[1].clone();
+        self.0[2] -= rhs.0[2].clone();
+        self.0[3] -= rhs.0[3].clone();
+        self.0[4] -= rhs.0[4].clone();
+        self.0[5] -= rhs.0[5].clone();
+        self.0[6] -= rhs.0[6].clone();
     }
 }
 


### PR DESCRIPTION
SubAssign only subtracted the first element instead of all 7. This broke the invariant that `a -= b` should equal `a = a - b`