### PR TITLE
fix: correct sys_rand safety documentation

### DIFF
--- a/crates/zkvm/entrypoint/src/syscalls/sys.rs
+++ b/crates/zkvm/entrypoint/src/syscalls/sys.rs
@@ -22,7 +22,7 @@ static SYS_RAND_WARNING: std::sync::Once = std::sync::Once::new();
 ///
 /// # Safety
 ///
-/// Make sure that `buf` has at least `nwords` words.
+/// The caller must ensure that `recv_buf` is valid for writes of at least `words` bytes.
 #[no_mangle]
 pub unsafe extern "C" fn sys_rand(recv_buf: *mut u8, words: usize) {
     SYS_RAND_WARNING.call_once(|| {


### PR DESCRIPTION
The safety documentation for sys_rand referenced an outdated API (buf/nwords words) and described the buffer size in words instead of bytes, which could mislead callers about how much memory must be writable.Summary: Updated the sys_rand safety comment to mention recv_buf and words explicitly and to describe words as a byte count, aligning the documentation with the current function signature and behavior.