### PR TITLE
build: harden rerun-if-changed path handling

### DIFF
--- a/crates/build/src/utils.rs
+++ b/crates/build/src/utils.rs
@@ -20,8 +20,14 @@ pub(crate) fn cargo_rerun_if_changed(metadata: &Metadata, program_dir: &Path) {
     ];
     for dir in dirs {
         if dir.exists() {
-            if let Ok(path) = dir.canonicalize() {
-                println!("cargo::rerun-if-changed={}", path.display());
+            if let Ok(canonical_path) = dir.canonicalize() {
+                println!("cargo::rerun-if-changed={}", canonical_path.display());
+            } else {
+                println!(
+                    "cargo::warning=Could not canonicalize path: {:?}, using original path",
+                    dir
+                );
+                println!("cargo::rerun-if-changed={}", dir.display());
             }
         }
     }

--- a/crates/build/src/utils.rs
+++ b/crates/build/src/utils.rs
@@ -20,19 +20,21 @@ pub(crate) fn cargo_rerun_if_changed(metadata: &Metadata, program_dir: &Path) {
     ];
     for dir in dirs {
         if dir.exists() {
-            println!("cargo::rerun-if-changed={}", dir.canonicalize().unwrap().display());
+            if let Ok(path) = dir.canonicalize() {
+                println!("cargo::rerun-if-changed={}", path.display());
+            }
         }
     }
 
     // Re-run the build script if the workspace root's Cargo.lock changes. If the program is its own
     // workspace, this will be the program's Cargo.lock.
-    println!("cargo:rerun-if-changed={}", metadata.workspace_root.join("Cargo.lock").as_str());
+    println!("cargo::rerun-if-changed={}", metadata.workspace_root.join("Cargo.lock").as_str());
 
     // Re-run if any local dependency changes.
     for package in &metadata.packages {
         for dependency in &package.dependencies {
             if let Some(path) = &dependency.path {
-                println!("cargo:rerun-if-changed={}", path.as_str());
+                println!("cargo::rerun-if-changed={}", path.as_str());
             }
         }
     }

--- a/crates/build/src/utils.rs
+++ b/crates/build/src/utils.rs
@@ -24,8 +24,7 @@ pub(crate) fn cargo_rerun_if_changed(metadata: &Metadata, program_dir: &Path) {
                 println!("cargo::rerun-if-changed={}", canonical_path.display());
             } else {
                 println!(
-                    "cargo::warning=Could not canonicalize path: {:?}, using original path",
-                    dir
+                    "cargo::warning=Could not canonicalize path: {dir:?}, using original path"
                 );
                 println!("cargo::rerun-if-changed={}", dir.display());
             }


### PR DESCRIPTION
Removes unwrap from build script path handling and improves robustness of rerun-if-changed logic