### PR TITLE
fix: correct SSL config condition in NetworkProver

### DIFF
--- a/crates/sdk/src/network/prover.rs
+++ b/crates/sdk/src/network/prover.rs
@@ -64,7 +64,7 @@ impl NetworkProver {
         );
         let ssl_cert_path = env::var("SSL_CERT_PATH").ok();
         let ssl_key_path = env::var("SSL_KEY_PATH").ok();
-        let ssl_config = if ca_cert_path.as_ref().is_none() {
+        let ssl_config = if ssl_cert_path.is_none() || ssl_key_path.is_none() {
             None
         } else {
             let (ca_cert, identity) = get_cert_and_identity(


### PR DESCRIPTION
The SSL config check was using `ca_cert_path.is_none()` which always returned false since `ca_cert_path` is always `Some(...)`. This caused a panic when `SSL_CERT_PATH` or `SSL_KEY_PATH` env vars were not set. Fixed by checking if ssl_cert_path or ssl_key_path are None instead.