### PR TITLE
chore: remove unused zkm-core-machine dependency from cli crate

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -21,6 +21,5 @@ anyhow = { version = "1.0.83", features = ["backtrace"] }
 clap = { version = "4.5.9", features = ["derive", "env"] }
 zkm-build = { workspace = true }
 zkm-sdk = { workspace = true }
-zkm-core-machine = { workspace = true }
 yansi = "1.0.1"
 cargo_metadata = "0.18.1"


### PR DESCRIPTION
zkm-core-machine was declared as a dependency in Cargo.toml but never imported in any source file of the cli crate.