### PR TITLE
fix: missing assert_bool for is_nor flag in BitwiseChip

### DIFF
--- a/crates/core/machine/src/alu/bitwise/mod.rs
+++ b/crates/core/machine/src/alu/bitwise/mod.rs
@@ -229,7 +229,7 @@ where
         builder.assert_bool(local.is_xor);
         builder.assert_bool(local.is_or);
         builder.assert_bool(local.is_and);
-        builder.assert_bool(local.is_xor);
+        builder.assert_bool(local.is_nor);
         builder.assert_bool(is_real);
     }
 }


### PR DESCRIPTION
Fixed copy-paste bug where is_xor was checked twice instead of checking is_nor. This left the is_nor boolean flag unconstrained in the AIR.