### PR TITLE
fix: incorrect arithmetic operation in SUB test data

### DIFF
--- a/crates/core/machine/src/alu/add_sub/mod.rs
+++ b/crates/core/machine/src/alu/add_sub/mod.rs
@@ -336,7 +336,7 @@ mod tests {
                 [{
                     let operand_1 = thread_rng().gen_range(0..u32::MAX);
                     let operand_2 = thread_rng().gen_range(0..u32::MAX);
-                    let result = operand_1.wrapping_add(operand_2);
+                    let result = operand_1.wrapping_sub(operand_2);
                     AluEvent::new(i % 2, Opcode::SUB, result, operand_1, operand_2)
                 }]
             })


### PR DESCRIPTION
_sub_events used wrapping_add instead of wrapping_sub to calculate expected result for Opcode::SUB.