### PR TITLE
fix: remove duplicate assert_bool constraints in ShiftRightChip

### DIFF
--- a/crates/core/machine/src/alu/sr/mod.rs
+++ b/crates/core/machine/src/alu/sr/mod.rs
@@ -502,13 +502,7 @@ where
             }
         }
 
-        // Check that the operation flags are boolean.
-        builder.assert_bool(local.is_srl);
-        builder.assert_bool(local.is_sra);
-        builder.assert_bool(local.is_ror);
-        builder.assert_bool(local.is_real);
-
-        // Check that is_real is the sum of the two operation flags.
+        // Check that is_real is the sum of the operation flags.
         builder.assert_eq(local.is_srl + local.is_sra + local.is_ror, local.is_real);
 
         // Receive the arguments.


### PR DESCRIPTION
The assert_bool checks for is_srl, is_sra, is_ror, and is_real were called twice - once in the flags array loop (line 476-479) and again individually below. This added 4 redundant constraints to the proof system. Removed the duplicates to reduce prover overhead.