### PR TITLE
fix: infinite recursion in Ed25519AffinePoint::identity()

### DIFF
--- a/crates/zkvm/lib/src/ed25519.rs
+++ b/crates/zkvm/lib/src/ed25519.rs
@@ -24,7 +24,7 @@ impl AffinePoint<N> for Ed25519AffinePoint {
     }
 
     fn identity() -> Self {
-        Self::identity()
+        Self(Self::IDENTITY)
     }
 
     fn limbs_ref(&self) -> &[u32; N] {


### PR DESCRIPTION
The trait method identity() was calling Self::identity() which resolves to itself, causing stack overflow when mul_assign() or multi_scalar_multiplication() is called on Ed25519 points.

Changed to return Self(Self::IDENTITY) directly, matching the pattern used in the inherent impl block.