### PR TITLE
fix: wrong gate count in last chunk of boolean_circuit_garble

### DIFF
--- a/crates/zkvm/lib/src/boolean_circuit_garble.rs
+++ b/crates/zkvm/lib/src/boolean_circuit_garble.rs
@@ -11,7 +11,7 @@ pub fn boolean_circuit_garble(gates_info: &[u8]) -> bool {
     let remainder = num_gates - base * (syscall_num - 1);
 
     let base_bytes = base.to_le_bytes();
-    let remainder_bytes = base.to_le_bytes();
+    let remainder_bytes = remainder.to_le_bytes();
 
     let delta = &gates_info[0..16];
     let mut output = 0_u32;


### PR DESCRIPTION
remainder_bytes was initialized with base.to_le_bytes() instead of remainder.to_le_bytes() (copy-paste error from line above).

This caused the last syscall to receive wrong gate count, potentially skipping gates when num_gates doesn't divide evenly into chunks.