### PR TITLE
chore: move serial_test to dev-dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7529,7 +7529,6 @@ dependencies = [
  "vergen",
  "yansi 1.0.1",
  "zkm-build",
- "zkm-core-machine",
  "zkm-sdk",
 ]
 

--- a/crates/prover/Cargo.toml
+++ b/crates/prover/Cargo.toml
@@ -35,7 +35,6 @@ serde_json = { workspace = true }
 clap = { version = "4.5.9", features = ["derive", "env"] }
 anyhow = "1.0.83"
 dirs = "5.0.1"
-serial_test = "3.1.1"
 num-bigint = "0.4.6"
 thiserror = "1.0.63"
 rayon = "1.10.0"
@@ -44,6 +43,7 @@ eyre = "0.6.12"
 
 [dev-dependencies]
 test-artifacts = { workspace = true }
+serial_test = "3.1.1"
 
 [[bin]]
 name = "build_plonk_bn254"


### PR DESCRIPTION
serial_test is only used in #[cfg(test)] blocks for the #[serial] attribute, so it belongs in dev-dependencies rather than regular dependencies. this reduces compile time and dependency tree for production builds.