### PR TITLE
fix(executor): use correct precompile event method for Secp256r1

### DIFF
--- a/crates/core/executor/src/syscalls/precompiles/weierstrass/add.rs
+++ b/crates/core/executor/src/syscalls/precompiles/weierstrass/add.rs
@@ -48,7 +48,7 @@ impl<E: EllipticCurve> Syscall for WeierstrassAddAssignSyscall<E> {
                 syscall_event,
                 PrecompileEvent::Bls12381Add(event),
             ),
-            CurveType::Secp256r1 => rt.record_mut().add_precompile_event(
+            CurveType::Secp256r1 => rt.add_precompile_event(
                 syscall_code,
                 syscall_event,
                 PrecompileEvent::Secp256r1Add(event),

--- a/crates/core/executor/src/syscalls/precompiles/weierstrass/double.rs
+++ b/crates/core/executor/src/syscalls/precompiles/weierstrass/double.rs
@@ -38,7 +38,7 @@ impl<E: EllipticCurve> Syscall for WeierstrassDoubleAssignSyscall<E> {
                     PrecompileEvent::Secp256k1Double(event),
                 );
             }
-            CurveType::Secp256r1 => rt.record_mut().add_precompile_event(
+            CurveType::Secp256r1 => rt.add_precompile_event(
                 syscall_code,
                 syscall_event,
                 PrecompileEvent::Secp256r1Double(event),


### PR DESCRIPTION
Secp256r1 was calling `rt.record_mut().add_precompile_event()` directly instead of `rt.add_precompile_event()`. This skips the ExecutorMode check, so events get recorded even when not in Trace mode. Other curves don't have this issue.