### PR TITLE
fix: remove redundant clone calls in operations

### DIFF
--- a/crates/core/machine/src/operations/add.rs
+++ b/crates/core/machine/src/operations/add.rs
@@ -72,7 +72,7 @@ impl<F: Field> AddOperation<F> {
         let overflow_2 = a[2] + b[2] - cols.value[2] + cols.carry[1];
         let overflow_3 = a[3] + b[3] - cols.value[3] + cols.carry[2];
 
-        builder_is_real.assert_zero(overflow_3.clone() * (overflow_3.clone() - base));
+        builder_is_real.assert_zero(overflow_3.clone() * (overflow_3 - base));
 
         // If the carry is one, then the overflow must be the base.
         builder_is_real.assert_zero(cols.carry[0] * (overflow_0.clone() - base));
@@ -80,9 +80,9 @@ impl<F: Field> AddOperation<F> {
         builder_is_real.assert_zero(cols.carry[2] * (overflow_2.clone() - base));
 
         // If the carry is not one, then the overflow must be zero.
-        builder_is_real.assert_zero((cols.carry[0] - one.clone()) * overflow_0.clone());
-        builder_is_real.assert_zero((cols.carry[1] - one.clone()) * overflow_1.clone());
-        builder_is_real.assert_zero((cols.carry[2] - one.clone()) * overflow_2.clone());
+        builder_is_real.assert_zero((cols.carry[0] - one.clone()) * overflow_0);
+        builder_is_real.assert_zero((cols.carry[1] - one.clone()) * overflow_1);
+        builder_is_real.assert_zero((cols.carry[2] - one) * overflow_2);
 
         // Assert that the carry is either zero or one.
         builder_is_real.assert_bool(cols.carry[0]);

--- a/crates/core/machine/src/operations/is_zero.rs
+++ b/crates/core/machine/src/operations/is_zero.rs
@@ -57,11 +57,11 @@ impl<F: Field> IsZeroOperation<F> {
 
         // If the input is 0, then any product involving it is 0. If it is nonzero and its inverse
         // is correctly set, then the product is 1.
-        let is_zero = one.clone() - cols.inverse * a.clone();
+        let is_zero = one - cols.inverse * a.clone();
         builder.when(is_real.clone()).assert_eq(is_zero, cols.result);
         builder.when(is_real.clone()).assert_bool(cols.result);
 
         // If the result is 1, then the input is 0.
-        builder.when(is_real.clone()).when(cols.result).assert_zero(a.clone());
+        builder.when(is_real).when(cols.result).assert_zero(a);
     }
 }


### PR DESCRIPTION
Just removed unnecessary `.clone()`.