### PR TITLE
chore: change the base value of boolean circuit garble

### DIFF
--- a/crates/zkvm/lib/src/boolean_circuit_garble.rs
+++ b/crates/zkvm/lib/src/boolean_circuit_garble.rs
@@ -7,7 +7,7 @@ pub fn boolean_circuit_garble(gates_info: &[u8]) -> bool {
 
     let num_gates = gates_info.len() / GATE_INFO_BYTES;
     let syscall_num = (num_gates - 1) / MAX_GATES_PER_SYSCALL + 1;
-    let base = num_gates / syscall_num;
+    let base = MAX_GATES_PER_SYSCALL;
     let remainder = num_gates - base * (syscall_num - 1);
 
     let base_bytes = base.to_le_bytes();


### PR DESCRIPTION
This PR ensures that the remainder <= base in all cases. 