### PR TITLE
fix(core): correct carry array size in Add5Operation

### DIFF
--- a/crates/core/machine/src/operations/add5.rs
+++ b/crates/core/machine/src/operations/add5.rs
@@ -56,7 +56,7 @@ impl<F: Field> Add5Operation<F> {
         let e = e_u32.to_le_bytes();
 
         let base = 256;
-        let mut carry = [0u8, 0u8, 0u8, 0u8, 0u8];
+        let mut carry = [0u8; WORD_SIZE];
         for i in 0..WORD_SIZE {
             let mut res =
                 (a[i] as u32) + (b[i] as u32) + (c[i] as u32) + (d[i] as u32) + (e[i] as u32);


### PR DESCRIPTION
The carry array in add5.rs was declared with 5 elements, but only 4 are ever used. The loop iterates over WORD_SIZE (4), so carry[4] is never accessed. This matches how add4.rs correctly uses a 4-element array.