### PR TITLE
fix(prover): remove leftover debug code

### DIFF
--- a/crates/prover/src/build.rs
+++ b/crates/prover/src/build.rs
@@ -146,14 +146,6 @@ pub fn build_dvsnark_bn254_artifacts(
 /// the circuit.
 pub fn build_plonk_bn254_artifacts_with_dummy(build_dir: impl Into<PathBuf>) {
     let (wrap_vk, wrapped_proof) = dummy_proof();
-    let wrap_vk_bytes = bincode::serialize(&wrap_vk).unwrap();
-    let wrapped_proof_bytes = bincode::serialize(&wrapped_proof).unwrap();
-    std::fs::write("wrap_vk.bin", wrap_vk_bytes).unwrap();
-    std::fs::write("wrapped_proof.bin", wrapped_proof_bytes).unwrap();
-    let wrap_vk_bytes = std::fs::read("wrap_vk.bin").unwrap();
-    let wrapped_proof_bytes = std::fs::read("wrapped_proof.bin").unwrap();
-    let wrap_vk = bincode::deserialize(&wrap_vk_bytes).unwrap();
-    let wrapped_proof = bincode::deserialize(&wrapped_proof_bytes).unwrap();
     crate::build::build_plonk_bn254_artifacts(&wrap_vk, &wrapped_proof, build_dir.into());
 }
 
@@ -163,14 +155,6 @@ pub fn build_plonk_bn254_artifacts_with_dummy(build_dir: impl Into<PathBuf>) {
 /// the circuit.
 pub fn build_groth16_bn254_artifacts_with_dummy(build_dir: impl Into<PathBuf>) {
     let (wrap_vk, wrapped_proof) = dummy_proof();
-    let wrap_vk_bytes = bincode::serialize(&wrap_vk).unwrap();
-    let wrapped_proof_bytes = bincode::serialize(&wrapped_proof).unwrap();
-    std::fs::write("wrap_vk.bin", wrap_vk_bytes).unwrap();
-    std::fs::write("wrapped_proof.bin", wrapped_proof_bytes).unwrap();
-    let wrap_vk_bytes = std::fs::read("wrap_vk.bin").unwrap();
-    let wrapped_proof_bytes = std::fs::read("wrapped_proof.bin").unwrap();
-    let wrap_vk = bincode::deserialize(&wrap_vk_bytes).unwrap();
-    let wrapped_proof = bincode::deserialize(&wrapped_proof_bytes).unwrap();
     crate::build::build_groth16_bn254_artifacts(&wrap_vk, &wrapped_proof, build_dir.into());
 }
 


### PR DESCRIPTION
Remove redundant serialize/write/read/deserialize cycle in build_plonk_bn254_artifacts_with_dummy and build_groth16_bn254_artifacts_with_dummy. Data already exists in memory after dummy_proof() call, 
no need to roundtrip through files in cwd.

If caching was intended here, should probably write to build_dir instead?