### PR TITLE
fix: ins ror_val out of range

### DIFF
--- a/crates/core/executor/src/artifacts/mips_costs.json
+++ b/crates/core/executor/src/artifacts/mips_costs.json
@@ -47,6 +47,6 @@
   "Cpu": 119,
   "ShaCompress": 40480,
   "MemoryInstrs": 115,
-  "MiscInstrs": 148,
+  "MiscInstrs": 152,
   "Secp256k1DoubleAssign": 4492
 }

--- a/crates/core/executor/src/dependencies.rs
+++ b/crates/core/executor/src/dependencies.rs
@@ -325,16 +325,27 @@ pub fn emit_misc_dependencies(executor: &mut Executor, event: MiscEvent) {
         };
         executor.record.shift_right_events.push(ror_event);
 
-        let width = msb - lsb + 1;
-        let srl_val = if width == 32 { 0 } else { ror_val >> width };
+        let srl1_val = ror_val >> 1;
+        let srl1_event = AluEvent {
+            pc: UNUSED_PC,
+            next_pc: UNUSED_PC + DEFAULT_PC_INC,
+            opcode: Opcode::SRL,
+            hi: 0,
+            a: srl1_val,
+            b: ror_val,
+            c: 1,
+        };
+        executor.record.shift_right_events.push(srl1_event);
+
+        let srl_val = srl1_val >> (msb - lsb);
         let srl_event = AluEvent {
             pc: UNUSED_PC,
             next_pc: UNUSED_PC + DEFAULT_PC_INC,
             opcode: Opcode::SRL,
             hi: 0,
             a: srl_val,
-            b: ror_val,
-            c: width,
+            b: srl1_val,
+            c: msb - lsb,
         };
         executor.record.shift_right_events.push(srl_event);
 

--- a/crates/core/executor/src/executor.rs
+++ b/crates/core/executor/src/executor.rs
@@ -1481,7 +1481,7 @@ impl<'a> Executor<'a> {
             } else if instruction.opcode == Opcode::INS {
                 self.local_counts.event_counts[Opcode::ROR] += 2;
                 self.local_counts.event_counts[Opcode::SLL] += 1;
-                self.local_counts.event_counts[Opcode::SRL] += 1;
+                self.local_counts.event_counts[Opcode::SRL] += 2;
                 self.local_counts.event_counts[Opcode::ADD] += 1;
             } else if instruction.opcode == Opcode::DIV {
                 self.local_counts.event_counts[Opcode::MULT] += 2;

--- a/crates/core/machine/src/misc/others/air.rs
+++ b/crates/core/machine/src/misc/others/air.rs
@@ -262,12 +262,18 @@ impl MiscInstrsChip {
     ) {
         let ins_cols = local.misc_specific_columns.ins();
 
-        // Ins can be divided into 5 operations:
-        //    ror_val = rotate_right(op_a, lsb)
-        //    srl_val = ror_val >> (msb - lsb + 1)
-        //    sll_val = op_b << (31 - msb + lsb)
-        //    add_val = srl_val + sll_val
-        //    result = rotate_right(op_a, 31 - msb)
+        // Ins is decomposed into 6 ALU sub-operations:
+        //    ror_val  = rotate_right(prev_a, lsb)            [shift: lsb ∈ 0..31]
+        //    srl1_val = ror_val >> 1                          [shift: 1]
+        //    srl_val  = srl1_val >> (msb - lsb)               [shift: msb-lsb ∈ 0..31]
+        //    sll_val  = op_b << (31 - msb + lsb)              [shift: ∈ 0..31]
+        //    add_val  = srl_val + sll_val
+        //    result   = rotate_right(add_val, 31 - msb)       [shift: ∈ 0..31]
+        //
+        // The original single SRL by `width = msb - lsb + 1` is split into two
+        // steps (`>> 1` then `>> (msb - lsb)`) so that each shift amount is
+        // always in [0, 31], avoiding the ShiftRight chip's range limitation
+        // when width = 32. All multiplicities remain degree 1.
         {
             builder.send_alu(
                 Opcode::ROR.as_field::<AB::F>(),
@@ -282,12 +288,27 @@ impl MiscInstrsChip {
                 local.is_ins,
             );
 
+            // SRL step 1: shift right by 1 (always in range).
+            builder.send_alu(
+                Opcode::SRL.as_field::<AB::F>(),
+                ins_cols.srl1_val,
+                ins_cols.ror_val,
+                Word([
+                    AB::Expr::one(),
+                    AB::Expr::zero(),
+                    AB::Expr::zero(),
+                    AB::Expr::zero(),
+                ]),
+                local.is_ins,
+            );
+
+            // SRL step 2: shift right by msb - lsb (range [0, 31]).
             builder.send_alu(
                 Opcode::SRL.as_field::<AB::F>(),
                 ins_cols.srl_val,
-                ins_cols.ror_val,
+                ins_cols.srl1_val,
                 Word([
-                    AB::Expr::from_canonical_u32(1) + ins_cols.msb - ins_cols.lsb,
+                    AB::Expr::from_canonical_u32(0) + ins_cols.msb - ins_cols.lsb,
                     AB::Expr::zero(),
                     AB::Expr::zero(),
                     AB::Expr::zero(),

--- a/crates/core/machine/src/misc/others/air.rs
+++ b/crates/core/machine/src/misc/others/air.rs
@@ -293,12 +293,7 @@ impl MiscInstrsChip {
                 Opcode::SRL.as_field::<AB::F>(),
                 ins_cols.srl1_val,
                 ins_cols.ror_val,
-                Word([
-                    AB::Expr::one(),
-                    AB::Expr::zero(),
-                    AB::Expr::zero(),
-                    AB::Expr::zero(),
-                ]),
+                Word([AB::Expr::one(), AB::Expr::zero(), AB::Expr::zero(), AB::Expr::zero()]),
                 local.is_ins,
             );
 

--- a/crates/core/machine/src/misc/others/columns/ins.rs
+++ b/crates/core/machine/src/misc/others/columns/ins.rs
@@ -13,7 +13,13 @@ pub struct InsCols<T> {
     pub msb: T,
 
     /// Result value of intermediate operations.
+    ///
+    /// The INS decomposition extracts the upper bits of prev_a via a right shift
+    /// by `width = msb - lsb + 1`. Since the ShiftRight chip only supports shift
+    /// amounts 0-31, we split this into two steps: `>> 1` then `>> (msb - lsb)`,
+    /// each of which is always in range [0, 31].
     pub ror_val: Word<T>,
+    pub srl1_val: Word<T>,
     pub srl_val: Word<T>,
     pub sll_val: Word<T>,
     pub add_val: Word<T>,

--- a/crates/core/machine/src/misc/others/mod.rs
+++ b/crates/core/machine/src/misc/others/mod.rs
@@ -60,4 +60,34 @@ mod tests {
         let program = Program::new(instructions, 0, 0);
         run_test::<CpuProver<_, _>>(program).unwrap();
     }
+
+    /// Test INS instruction with width=32 (lsb=0, msb=31), the edge case fixed
+    /// by splitting the SRL into two steps to keep each shift amount in [0, 31].
+    #[test]
+    fn test_ins_offset_32() {
+        utils::setup_logger();
+        // INS c encoding: lsb | (msb << 5)
+        // width = msb - lsb + 1
+        let instructions = vec![
+            // Set up source registers with non-trivial values.
+            Instruction::new(Opcode::ADD, 29, 0, 0xDEAD, false, true),
+            Instruction::new(Opcode::ADD, 28, 0, 0xBEEF, false, true),
+            // width=32: lsb=0, msb=31 -> c = 0 | (31 << 5) = 0x3E0
+            Instruction::new(Opcode::INS, 30, 29, 0x3E0, false, true),
+            // width=32 with different registers
+            Instruction::new(Opcode::INS, 31, 28, 0x3E0, false, true),
+            // width=32 with zero dest
+            Instruction::new(Opcode::INS, 0, 29, 0x3E0, false, true),
+            // width=31: lsb=0, msb=30 -> c = 0 | (30 << 5) = 0x3C0
+            Instruction::new(Opcode::INS, 30, 28, 0x3C0, false, true),
+            // width=1: lsb=0, msb=0 -> c = 0
+            Instruction::new(Opcode::INS, 30, 29, 0x0, false, true),
+            // width=1: lsb=31, msb=31 -> c = 31 | (31 << 5) = 0x3FF
+            Instruction::new(Opcode::INS, 30, 28, 0x3FF, false, true),
+            // width=16: lsb=8, msb=23 -> c = 8 | (23 << 5) = 0x2E8
+            Instruction::new(Opcode::INS, 30, 29, 0x2E8, false, true),
+        ];
+        let program = Program::new(instructions, 0, 0);
+        run_test::<CpuProver<_, _>>(program).unwrap();
+    }
 }

--- a/crates/core/machine/src/misc/others/trace.rs
+++ b/crates/core/machine/src/misc/others/trace.rs
@@ -231,12 +231,14 @@ impl MiscInstrsChip {
         let lsb = event.c & 0x1f;
         let msb = event.c >> 5;
         let ror_val = event.prev_a.rotate_right(lsb);
-        let srl_val = ror_val >> (msb - lsb + 1);
+        let srl1_val = ror_val >> 1;
+        let srl_val = srl1_val >> (msb - lsb);
         let sll_val = event.b << (31 - msb + lsb);
         let add_val = srl_val + sll_val;
         ins_cols.lsb = F::from_canonical_u32(lsb);
         ins_cols.msb = F::from_canonical_u32(msb);
         ins_cols.ror_val = Word::from(ror_val);
+        ins_cols.srl1_val = Word::from(srl1_val);
         ins_cols.srl_val = Word::from(srl_val);
         ins_cols.sll_val = Word::from(sll_val);
         ins_cols.add_val = Word::from(add_val);

--- a/crates/core/machine/src/operations/add.rs
+++ b/crates/core/machine/src/operations/add.rs
@@ -40,9 +40,9 @@ impl<F: Field> AddOperation<F> {
             self.carry[2] = F::ONE;
         }
 
-        let base = 256u32;
-        let overflow = a[3].wrapping_add(b[3]).wrapping_sub(expected.to_le_bytes()[3]) as u32;
-        debug_assert_eq!(overflow.wrapping_mul(overflow.wrapping_sub(base)), 0);
+        let overflow =
+            (a[3] as u32) + (b[3] as u32) + (carry[2] as u32) - (expected.to_le_bytes()[3] as u32);
+        debug_assert!(overflow == 0 || overflow == 256);
 
         // Range check
         {

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,83 +1,15 @@
 [workspace]
 members = [
-  "aggregation/guest",
-  "aggregation/host",
-  "bn254/guest",
-  "bn254/host",
-  "chess/guest",
-  "chess/host",
-  "cycle-tracking/guest",
-  "cycle-tracking/host",
-  "fibonacci/guest",
-  "fibonacci/host",
-  "fibonacci_c_lib/guest",
-  "fibonacci_c_lib/host",
-  "groth16/guest",
-  "groth16/host",
-  "bitcoin/host",
-  "bitcoin/guest",
-  "is-prime/guest",
-  "is-prime/host",
-  "json/lib",
-  "json/guest",
-  "json/host",
-  "keccak-precompile/guest",
-  "keccak-precompile/host",
-  "plonk/guest",
-  "plonk/host",
-  "poseidon2/guest",
-  "poseidon2/host",
-  "regex/guest",
-  "regex/host",
-  "rsa/guest",
-  "rsa/host",
-  "ssz-withdrawals/guest",
-  "ssz-withdrawals/host",
-  "tendermint/guest",
-  "tendermint/host",
-  "unconstrained/guest",
-  "unconstrained/host",
-  "large-sum/guest",
-  "large-sum/host",
-  "simple-go/host",
-  "keeper/host",
+    "guest",
+    "host",
 ]
 resolver = "2"
+default-members = ["host"]
 
-[workspace.package]
-version = "1.1.0"
-edition = "2021"
 
 [workspace.dependencies]
-zkm-build = { path = "../crates/build" }
-zkm-derive = { path = "../crates/derive" }
-zkm-core-executor = { path = "../crates/core/executor" }
-zkm-core-machine = { path = "../crates/core/machine" }
-zkm-cli = { path = "../crates/cli", default-features = false }
-zkm-eval = { path = "../crates/eval", default-features = false }
-zkm-helper = { path = "../crates/helper", default-features = false }
-zkm-primitives = { path = "../crates/primitives" }
-zkm-prover = { path = "../crates/prover" }
-zkm-recursion-compiler = { path = "../crates/recursion/compiler" }
-zkm-recursion-core = { path = "../crates/recursion/core", default-features = false }
-zkm-recursion-derive = { path = "../crates/recursion/derive", default-features = false }
-zkm-recursion-gnark-ffi = { path = "../crates/recursion/gnark-ffi", default-features = false }
-zkm-recursion-circuit = { path = "../crates/recursion/circuit", default-features = false }
-zkm-sdk = { path = "../crates/sdk" }
-zkm-lib = { path = "../crates/zkvm/lib", default-features = false }
-zkm-zkvm = { path = "../crates/zkvm/entrypoint", default-features = false }
+zkm-sdk = { path = "../../crates/sdk" }
+zkm-build = { path = "../../crates/build" }
+zkm-zkvm = { path = "../../crates/zkvm/entrypoint" }
 
-# misc
-serde = "1.0.204"
-serde_json = "1.0.132"
-tracing = "0.1.40"
-
-[patch.crates-io]
-curve25519-dalek = { git = "https://github.com/ziren-patches/curve25519-dalek", branch = "patch-4.1.3" }
-ecdsa-core = { git = "https://github.com/ziren-patches/signatures", package = "ecdsa", branch = "patch-ecdsa-0.16.9" }
-rsa = { git = "https://github.com/ziren-patches/RustCrypto-RSA.git", branch = "patch-rsa-0.9.6" }
-secp256k1 = { git = "https://github.com/ziren-patches/rust-secp256k1", branch = "patch-0.29.1" }
-sha2-v0-10-8 = { git = "https://github.com/ziren-patches/RustCrypto-hashes", package = "sha2", branch = "patch-sha2-0.10.8" }
-substrate-bn = { git = "https://github.com/ziren-patches/bn", branch = "patch-0.6.0" }
-k256 = { git = "https://github.com/ziren-patches/elliptic-curves", branch = "patch-k256-0.13.4" }
-p256 = { git = "https://github.com/ziren-patches/elliptic-curves", branch = "patch-p256-0.13.2" }
+clap = { version = "4.0", features = ["derive", "env"] }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,15 +1,83 @@
 [workspace]
 members = [
-    "guest",
-    "host",
+  "aggregation/guest",
+  "aggregation/host",
+  "bn254/guest",
+  "bn254/host",
+  "chess/guest",
+  "chess/host",
+  "cycle-tracking/guest",
+  "cycle-tracking/host",
+  "fibonacci/guest",
+  "fibonacci/host",
+  "fibonacci_c_lib/guest",
+  "fibonacci_c_lib/host",
+  "groth16/guest",
+  "groth16/host",
+  "bitcoin/host",
+  "bitcoin/guest",
+  "is-prime/guest",
+  "is-prime/host",
+  "json/lib",
+  "json/guest",
+  "json/host",
+  "keccak-precompile/guest",
+  "keccak-precompile/host",
+  "plonk/guest",
+  "plonk/host",
+  "poseidon2/guest",
+  "poseidon2/host",
+  "regex/guest",
+  "regex/host",
+  "rsa/guest",
+  "rsa/host",
+  "ssz-withdrawals/guest",
+  "ssz-withdrawals/host",
+  "tendermint/guest",
+  "tendermint/host",
+  "unconstrained/guest",
+  "unconstrained/host",
+  "large-sum/guest",
+  "large-sum/host",
+  "simple-go/host",
+  "keeper/host",
 ]
 resolver = "2"
-default-members = ["host"]
 
+[workspace.package]
+version = "1.1.0"
+edition = "2021"
 
 [workspace.dependencies]
-zkm-sdk = { path = "../../crates/sdk" }
-zkm-build = { path = "../../crates/build" }
-zkm-zkvm = { path = "../../crates/zkvm/entrypoint" }
+zkm-build = { path = "../crates/build" }
+zkm-derive = { path = "../crates/derive" }
+zkm-core-executor = { path = "../crates/core/executor" }
+zkm-core-machine = { path = "../crates/core/machine" }
+zkm-cli = { path = "../crates/cli", default-features = false }
+zkm-eval = { path = "../crates/eval", default-features = false }
+zkm-helper = { path = "../crates/helper", default-features = false }
+zkm-primitives = { path = "../crates/primitives" }
+zkm-prover = { path = "../crates/prover" }
+zkm-recursion-compiler = { path = "../crates/recursion/compiler" }
+zkm-recursion-core = { path = "../crates/recursion/core", default-features = false }
+zkm-recursion-derive = { path = "../crates/recursion/derive", default-features = false }
+zkm-recursion-gnark-ffi = { path = "../crates/recursion/gnark-ffi", default-features = false }
+zkm-recursion-circuit = { path = "../crates/recursion/circuit", default-features = false }
+zkm-sdk = { path = "../crates/sdk" }
+zkm-lib = { path = "../crates/zkvm/lib", default-features = false }
+zkm-zkvm = { path = "../crates/zkvm/entrypoint", default-features = false }
 
-clap = { version = "4.0", features = ["derive", "env"] }
+# misc
+serde = "1.0.204"
+serde_json = "1.0.132"
+tracing = "0.1.40"
+
+[patch.crates-io]
+curve25519-dalek = { git = "https://github.com/ziren-patches/curve25519-dalek", branch = "patch-4.1.3" }
+ecdsa-core = { git = "https://github.com/ziren-patches/signatures", package = "ecdsa", branch = "patch-ecdsa-0.16.9" }
+rsa = { git = "https://github.com/ziren-patches/RustCrypto-RSA.git", branch = "patch-rsa-0.9.6" }
+secp256k1 = { git = "https://github.com/ziren-patches/rust-secp256k1", branch = "patch-0.29.1" }
+sha2-v0-10-8 = { git = "https://github.com/ziren-patches/RustCrypto-hashes", package = "sha2", branch = "patch-sha2-0.10.8" }
+substrate-bn = { git = "https://github.com/ziren-patches/bn", branch = "patch-0.6.0" }
+k256 = { git = "https://github.com/ziren-patches/elliptic-curves", branch = "patch-k256-0.13.4" }
+p256 = { git = "https://github.com/ziren-patches/elliptic-curves", branch = "patch-p256-0.13.2" }


### PR DESCRIPTION
The INS instruction shifted ror_val right by msb - lsb + 1. When   
  msb=31, lsb=0, the shift amount is 32, exceeding the ShiftRight chip's [0,  
  31] range limit.  

Fix 1: Split INS SRL into two steps (across multiple files)                 
                                         
  Problem: The INS instruction shifted ror_val right by msb - lsb + 1. When   
  msb=31, lsb=0, the shift amount is 32, exceeding the ShiftRight chip's [0,  
  31] range limit.                                                            
                                                            
  Fix: Split the single >> (msb - lsb + 1) into two steps:
  - srl1_val = ror_val >> 1 (always 1, in range)
  - srl_val = srl1_val >> (msb - lsb) (shift amount ∈ [0, 31])                
                                                                                                                                              
  Fix 2: add.rs:43-44 debug_assert correction (just now)                      
                                                                              
  Problem: The debug_assert for byte 3 overflow omitted carry[2]:             
  // Old: missing carry[2]                                                    
  let overflow = a[3].wrapping_add(b[3]).wrapping_sub(expected[3]) as u32;    
  When byte 2 produces a carry (carry[2]=1) but byte 3 doesn't overflow,      
  overflow evaluates to 255 instead of 0, triggering the assertion.           
                                                                              
  Fix: Use correct u32 arithmetic including carry[2]:                         
  // New: correct                                                             
  let overflow = (a[3] as u32) + (b[3] as u32) + (carry[2] as u32) -
  (expected[3] as u32);                                             
  debug_assert!(overflow == 0 || overflow == 256);                            
                                                  
  The AIR constraint in eval() (line 73: overflow_3 = a[3] + b[3] - value[3] +
   carry[2]) was always correct. Only the debug_assert in populate had the    
  latent bug, which was exposed by the new intermediate values from Fix 1.