### PR TITLE
opt: circuit(CloClz, LT and ShiftRight)

### DIFF
--- a/crates/core/machine/src/alu/clo_clz/mod.rs
+++ b/crates/core/machine/src/alu/clo_clz/mod.rs
@@ -30,15 +30,14 @@ use crate::{air::ZKMCoreAirBuilder, utils::pad_rows_fixed, CoreChipError};
 /// The number of main trace columns for `CloClzChip`.
 pub const NUM_CLOCLZ_COLS: usize = size_of::<CloClzCols<u8>>();
 
-/// The size of a byte in bits.
-#[allow(dead_code)]
-const BYTE_SIZE: usize = 8;
-
 /// A chip that implements addition for the opcodes CLO/CLZ.
 #[derive(Default)]
 pub struct CloClzChip;
 
 /// The column layout for the chip.
+///
+/// Optimized: `sr1` removed (hardcoded as 1 in SRL lookup since we always verify sr1 == 1),
+/// `is_clo` removed (derived as `is_real - is_clz`).
 #[derive(AlignedBorrow, PicusAnnotations, Default, Debug, Clone, Copy)]
 #[repr(C)]
 pub struct CloClzCols<T> {
@@ -52,23 +51,16 @@ pub struct CloClzCols<T> {
     /// The input operand.
     pub b: Word<T>,
 
-    /// if clo, bb == b
-    /// if clz, bb == 0xffffffff - b
+    /// if clo, bb == 0xffffffff - b
+    /// if clz, bb == b
     pub bb: Word<T>,
 
     /// whether the `bb` is zero.
     pub is_bb_zero: T,
 
-    /// bb shift right by `32 - (result + 1)`.
-    pub sr1: Word<T>,
-
     /// Flag to indicate whether the opcode is CLZ.
     #[picus(selector)]
     pub is_clz: T,
-
-    /// Flag to indicate whether the opcode is CLO.
-    #[picus(selector)]
-    pub is_clo: T,
 
     /// Selector to know whether this row is enabled.
     pub is_real: T,
@@ -107,7 +99,6 @@ impl<F: PrimeField32> MachineAir<F> for CloClzChip {
             cols.pc = F::from_canonical_u32(event.pc);
             cols.next_pc = F::from_canonical_u32(event.next_pc);
             cols.is_real = F::ONE;
-            cols.is_clo = F::from_bool(event.opcode == Opcode::CLO);
             cols.is_clz = F::from_bool(event.opcode == Opcode::CLZ);
 
             let bb = if event.opcode == Opcode::CLZ { event.b } else { 0xffffffff - event.b };
@@ -115,11 +106,6 @@ impl<F: PrimeField32> MachineAir<F> for CloClzChip {
 
             // if bb == 0, then result is 32.
             cols.is_bb_zero = F::from_bool(bb == 0);
-
-            if bb != 0 {
-                let sr1_val = bb >> (31 - event.a);
-                cols.sr1 = Word::from(sr1_val);
-            }
 
             // Range check.
             output.add_u8_range_checks(&bb.to_le_bytes());
@@ -150,7 +136,7 @@ impl<F: PrimeField32> MachineAir<F> for CloClzChip {
         let padded_row_template = {
             let mut row = [F::ZERO; NUM_CLOCLZ_COLS];
             let cols: &mut CloClzCols<F> = row.as_mut_slice().borrow_mut();
-            // Padding rows: is_real=0, is_clo=0, is_clz=0, is_bb_zero=1, a=32.
+            // Padding rows: is_real=0, is_clz=0, is_bb_zero=1, a=32.
             // is_bb_zero=1 ensures send_alu for SRL has zero multiplicity.
             cols.a = Word::from(32);
             cols.is_bb_zero = F::ONE;
@@ -191,10 +177,13 @@ where
         let one: AB::Expr = AB::F::ONE.into();
         let zero: AB::Expr = AB::F::ZERO.into();
 
+        // Derive is_clo from is_real and is_clz.
+        let is_clo: AB::Expr = local.is_real.into() - local.is_clz.into();
+
         // if clz, bb == b, else bb = !b
         {
             local.b.0.iter().zip_eq(local.bb.0.iter()).for_each(|(a, b)| {
-                builder.when(local.is_clo).assert_eq(*a + *b, AB::Expr::from_canonical_u32(255));
+                builder.when(is_clo.clone()).assert_eq(*a + *b, AB::Expr::from_canonical_u32(255));
                 builder.when(local.is_clz).assert_eq(*a, *b);
             });
 
@@ -216,7 +205,10 @@ where
         builder.when(local.is_real).assert_zero(local.a[3]);
 
         // Get the opcode for the operation.
-        let cpu_opcode = local.is_clo * Opcode::CLO.as_field::<AB::F>()
+        // is_clo = is_real - is_clz, so:
+        //   opcode = (is_real - is_clz) * CLO + is_clz * CLZ
+        //          = is_real * CLO + is_clz * (CLZ - CLO)
+        let cpu_opcode = is_clo.clone() * Opcode::CLO.as_field::<AB::F>()
             + local.is_clz * Opcode::CLZ.as_field::<AB::F>();
 
         builder.receive_instruction(
@@ -250,10 +242,12 @@ where
         }
 
         {
-            // Use the SRL table to compute bb >> (31 - result).
+            // Use the SRL table to verify bb >> (31 - result) == 1.
+            // Since sr1 is always 1 when bb != 0, we hardcode the expected result
+            // as Word([1, 0, 0, 0]) directly, eliminating 4 witness columns.
             builder.send_alu(
                 Opcode::SRL.as_field::<AB::F>(),
-                local.sr1,
+                Word([one.clone(), zero.clone(), zero.clone(), zero.clone()]),
                 local.bb,
                 Word([
                     AB::Expr::from_canonical_u32(31) - local.a[0],
@@ -265,16 +259,13 @@ where
             );
         }
 
-        // if bb!=0, check sr1 == 1
-        {
-            builder.when_not(local.is_bb_zero).assert_one(local.sr1.reduce::<AB>());
-            builder.when_not(local.is_bb_zero).assert_zero(local.sr1[3]);
-        }
-
-        builder.assert_bool(local.is_clo);
+        // is_clz and is_real are boolean; is_clo = is_real - is_clz must also be boolean,
+        // which is equivalent to: is_clz = 1 implies is_real = 1.
         builder.assert_bool(local.is_clz);
         builder.assert_bool(local.is_real);
-        builder.assert_eq(local.is_real, local.is_clo + local.is_clz);
+        builder
+            .when(local.is_clz)
+            .assert_one(local.is_real);
     }
 }
 

--- a/crates/core/machine/src/alu/clo_clz/mod.rs
+++ b/crates/core/machine/src/alu/clo_clz/mod.rs
@@ -263,9 +263,7 @@ where
         // which is equivalent to: is_clz = 1 implies is_real = 1.
         builder.assert_bool(local.is_clz);
         builder.assert_bool(local.is_real);
-        builder
-            .when(local.is_clz)
-            .assert_one(local.is_real);
+        builder.when(local.is_clz).assert_one(local.is_real);
     }
 }
 

--- a/crates/core/machine/src/alu/lt/mod.rs
+++ b/crates/core/machine/src/alu/lt/mod.rs
@@ -83,8 +83,6 @@ pub struct LtCols<T> {
     pub is_sign_eq: T,
     /// The comparison bytes to be looked up.
     pub comparison_bytes: [T; 2],
-    /// Boolean fags to indicate which byte differs between the operands `b_comp`, `c_comp`.
-    pub byte_equality_check: [T; 4],
 }
 
 impl LtCols<u32> {

--- a/crates/core/machine/src/alu/sr/mod.rs
+++ b/crates/core/machine/src/alu/sr/mod.rs
@@ -90,9 +90,6 @@ pub struct ShiftRightCols<T> {
     pub pc: T,
     pub next_pc: T,
 
-    /// The output operand.
-    pub a: Word<T>,
-
     /// The first input operand.
     pub b: Word<T>,
 
@@ -234,7 +231,6 @@ impl ShiftRightChip {
         {
             cols.pc = F::from_canonical_u32(event.pc);
             cols.next_pc = F::from_canonical_u32(event.next_pc);
-            cols.a = Word::from(event.a);
             cols.b = Word::from(event.b);
             cols.c = Word::from(event.c);
 
@@ -321,7 +317,10 @@ impl ShiftRightChip {
             cols.shr_carry_output_shifted_byte =
                 shr_carry_output_shifted_byte.map(F::from_canonical_u8);
             for i in 0..WORD_SIZE {
-                debug_assert_eq!(cols.a[i], cols.bit_shift_result[i].clone());
+                debug_assert_eq!(
+                    cols.bit_shift_result[i],
+                    F::from_canonical_u8(event.a.to_le_bytes()[i])
+                );
             }
             // Range checks.
             blu.add_u8_range_checks(&byte_shift_result);
@@ -470,14 +469,6 @@ where
             }
         }
 
-        // The 4 least significant bytes must match a. The 4 most significant bytes of result may be
-        // inaccurate.
-        {
-            for i in 0..WORD_SIZE {
-                builder.assert_eq(local.a[i], local.bit_shift_result[i]);
-            }
-        }
-
         // Check that the flags are indeed boolean.
         {
             let flags = [local.is_srl, local.is_sra, local.is_ror, local.is_real, local.b_msb];
@@ -513,6 +504,14 @@ where
         builder.assert_eq(local.is_srl + local.is_sra + local.is_ror, local.is_real);
 
         // Receive the arguments.
+        // Use bit_shift_result[0..4] directly as the output operand `a`, eliminating the
+        // redundant `a` column since a[i] == bit_shift_result[i] is always true.
+        let a_word = Word([
+            local.bit_shift_result[0],
+            local.bit_shift_result[1],
+            local.bit_shift_result[2],
+            local.bit_shift_result[3],
+        ]);
         builder.receive_instruction(
             AB::Expr::zero(),
             AB::Expr::zero(),
@@ -523,7 +522,7 @@ where
             local.is_srl * AB::F::from_canonical_u32(Opcode::SRL as u32)
                 + local.is_sra * AB::F::from_canonical_u32(Opcode::SRA as u32)
                 + local.is_ror * AB::F::from_canonical_u32(Opcode::ROR as u32),
-            local.a,
+            a_word,
             local.b,
             local.c,
             Word([AB::Expr::zero(), AB::Expr::zero(), AB::Expr::zero(), AB::Expr::zero()]),


### PR DESCRIPTION
## Summary 

- **optimize(CloClz):** Remove 5 witness columns (22 → 17, −23%):
    - `sr1: Word<T>` (4 cols) — hardcode `[1, 0, 0, 0]` in `send_alu` since   
  `sr1 == 1` is always verified.                                              
    - `is_clo` (1 col) — derive as `is_real - is_clz` with a single           
  `when(is_clz).assert_one(is_real)` guard. 

- **optimize(Lt):** Remove 4 dead columns `byte_equality_check: [T; 4]` (35
  → 31, −11%). The field was declared but never referenced in `Air::eval` or  
  trace generation.   
                                        
- **optimize(ShiftRight):** Remove 4 redundant columns `a: Word<T>` (73 →   
  69, −5%). Since `a[i] == bit_shift_result[i]` always holds, pass            
  `bit_shift_result[0..4]` directly to `receive_instruction`.


## Column savings                                                           
                                                            
  | Chip | Before | After | Saved |                                           
  |------|--------|-------|-------|
  | CloClz | 22 | 17 | 5 (−23%) |                                             
  | Lt | 35 | 31 | 4 (−11%) |                                                 
  | ShiftRight | 73 | 69 | 4 (−5%) |                                          
  | **Total** | | | **13 columns** | 