### PR TITLE
adding mipstests from regression test suite

### DIFF
--- a/crates/core/executor/tests/n44_div.rs
+++ b/crates/core/executor/tests/n44_div.rs
@@ -1,0 +1,201 @@
+use std::panic::{catch_unwind, AssertUnwindSafe};
+
+use zkm_core_executor::{ExecutionError, Executor, Instruction, Opcode, Program, Register};
+use zkm_stark::ZKMCoreOpts;
+
+#[derive(Clone, Copy, Debug)]
+struct DivCase {
+    lhs: u32,
+    rhs: u32,
+    expected_lo: u32,
+    expected_hi: u32,
+}
+
+/// Build the smallest program that isolates signed `DIV`.
+///
+/// The program loads the dividend and divisor into `t0` and `t1`, executes `DIV`, then leaves
+/// the quotient in `LO` and the remainder in `HI`.
+fn div_program(case: DivCase) -> Program {
+    let instructions = vec![
+        Instruction::new(Opcode::ADD, Register::T0 as u8, 0, case.lhs, false, true),
+        Instruction::new(Opcode::ADD, Register::T1 as u8, 0, case.rhs, false, true),
+        Instruction::new(
+            Opcode::DIV,
+            Register::LO as u8,
+            Register::T0 as u32,
+            Register::T1 as u32,
+            false,
+            false,
+        ),
+    ];
+    Program::new(instructions, 0, 0)
+}
+
+/// Regression vectors copied from `mipstest/insttest/src/n44_div.S`.
+///
+/// These include positive and negative signed divisions, divisors larger than the dividend, and
+/// the zero-dividend boundary vectors from the end of the assembly test.
+#[test]
+fn n44_div_vectors() {
+    let cases = [
+        DivCase {
+            lhs: 0x56bedfa4,
+            rhs: 0x20831400,
+            expected_lo: 0x00000002,
+            expected_hi: 0x15b8b7a4,
+        },
+        DivCase {
+            lhs: 0xfda5ea8a,
+            rhs: 0xfac1873c,
+            expected_lo: 0x00000000,
+            expected_hi: 0xfda5ea8a,
+        },
+        DivCase {
+            lhs: 0x53eb4a70,
+            rhs: 0x07e13dd1,
+            expected_lo: 0x0000000a,
+            expected_hi: 0x051ee046,
+        },
+        DivCase {
+            lhs: 0x323676e0,
+            rhs: 0xdc3a3f10,
+            expected_lo: 0xffffffff,
+            expected_hi: 0x0e70b5f0,
+        },
+        DivCase {
+            lhs: 0xc3e0f060,
+            rhs: 0xe9c97944,
+            expected_lo: 0x00000002,
+            expected_hi: 0xf04dfdd8,
+        },
+        DivCase {
+            lhs: 0x7c7b85f2,
+            rhs: 0xdb7e6dc0,
+            expected_lo: 0xfffffffd,
+            expected_hi: 0x0ef6cf32,
+        },
+        DivCase {
+            lhs: 0x3bbf1da0,
+            rhs: 0xe73f9eea,
+            expected_lo: 0xfffffffe,
+            expected_hi: 0x0a3e5b74,
+        },
+        DivCase {
+            lhs: 0x8786a50c,
+            rhs: 0x412dc050,
+            expected_lo: 0xffffffff,
+            expected_hi: 0xc8b4655c,
+        },
+        DivCase {
+            lhs: 0xee98aaf8,
+            rhs: 0x36730f80,
+            expected_lo: 0x00000000,
+            expected_hi: 0xee98aaf8,
+        },
+        DivCase {
+            lhs: 0x68d65d90,
+            rhs: 0xd6d52b70,
+            expected_lo: 0xfffffffe,
+            expected_hi: 0x1680b470,
+        },
+        DivCase {
+            lhs: 0x17779850,
+            rhs: 0x511b1fba,
+            expected_lo: 0x00000000,
+            expected_hi: 0x17779850,
+        },
+        DivCase {
+            lhs: 0x7bfc98c0,
+            rhs: 0xdffb8d8c,
+            expected_lo: 0xfffffffd,
+            expected_hi: 0x1bef4164,
+        },
+        DivCase {
+            lhs: 0x00000000,
+            rhs: 0xa7bb1ef0,
+            expected_lo: 0x00000000,
+            expected_hi: 0x00000000,
+        },
+        DivCase {
+            lhs: 0x00000000,
+            rhs: 0x3050efec,
+            expected_lo: 0x00000000,
+            expected_hi: 0x00000000,
+        },
+        DivCase {
+            lhs: 0x00000000,
+            rhs: 0x94e29c00,
+            expected_lo: 0x00000000,
+            expected_hi: 0x00000000,
+        },
+    ];
+
+    for (i, case) in cases.into_iter().enumerate() {
+        let mut runtime = Executor::new(div_program(case), ZKMCoreOpts::default());
+        runtime.run_very_fast().unwrap();
+
+        assert_eq!(runtime.register(Register::T0), case.lhs, "case {i}: DIV should preserve lhs");
+        assert_eq!(runtime.register(Register::T1), case.rhs, "case {i}: DIV should preserve rhs");
+        assert_eq!(runtime.register(Register::LO), case.expected_lo, "case {i}: DIV LO mismatch");
+        assert_eq!(runtime.register(Register::HI), case.expected_hi, "case {i}: DIV HI mismatch");
+    }
+}
+
+/// Hand-written signed division cases for divisor `-1` that do not hit the `INT_MIN / -1`
+/// overflow path.
+#[test]
+fn n44_div_negative_one_divisor_vectors() {
+    let cases = [
+        DivCase { lhs: 5, rhs: (-1i32) as u32, expected_lo: (-5i32) as u32, expected_hi: 0 },
+        DivCase { lhs: (-5i32) as u32, rhs: (-1i32) as u32, expected_lo: 5, expected_hi: 0 },
+        DivCase {
+            lhs: i32::MAX as u32,
+            rhs: (-1i32) as u32,
+            expected_lo: (-(i32::MAX)) as u32,
+            expected_hi: 0,
+        },
+        DivCase {
+            lhs: (-123456789i32) as u32,
+            rhs: (-1i32) as u32,
+            expected_lo: 123456789u32,
+            expected_hi: 0,
+        },
+    ];
+
+    for (i, case) in cases.into_iter().enumerate() {
+        let mut runtime = Executor::new(div_program(case), ZKMCoreOpts::default());
+        runtime.run_very_fast().unwrap();
+
+        assert_eq!(runtime.register(Register::T0), case.lhs, "case {i}: DIV should preserve lhs");
+        assert_eq!(runtime.register(Register::T1), case.rhs, "case {i}: DIV should preserve rhs");
+        assert_eq!(runtime.register(Register::LO), case.expected_lo, "case {i}: DIV LO mismatch");
+        assert_eq!(runtime.register(Register::HI), case.expected_hi, "case {i}: DIV HI mismatch");
+    }
+}
+
+/// `DIV` should trap on a zero divisor before it attempts the arithmetic.
+#[test]
+fn n44_div_by_zero_traps() {
+    let case = DivCase { lhs: 0x1234_5678, rhs: 0x0000_0000, expected_lo: 0, expected_hi: 0 };
+
+    let mut runtime = Executor::new(div_program(case), ZKMCoreOpts::default());
+    let err = runtime.run_very_fast().unwrap_err();
+    assert!(matches!(err, ExecutionError::ExceptionOrTrap()));
+}
+
+/// Signed `INT_MIN / -1` is the unique overflow case.
+///
+/// The machine AIR models this explicitly, but the executor currently performs raw Rust signed
+/// division, so this edge case panics in debug builds instead of returning a normal result.
+#[test]
+fn n44_div_int_min_overflow_panics() {
+    let case =
+        DivCase { lhs: i32::MIN as u32, rhs: (-1i32) as u32, expected_lo: 0, expected_hi: 0 };
+
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        let mut runtime = Executor::new(div_program(case), ZKMCoreOpts::default());
+        let _ = runtime.run_very_fast();
+    }));
+
+    assert!(result.is_err(), "INT_MIN / -1 should currently panic in the executor");
+}

--- a/crates/core/executor/tests/n45_divu.rs
+++ b/crates/core/executor/tests/n45_divu.rs
@@ -1,0 +1,164 @@
+use zkm_core_executor::{Executor, Instruction, Opcode, Program, Register};
+use zkm_stark::ZKMCoreOpts;
+
+#[derive(Clone, Copy, Debug)]
+struct DivuCase {
+    lhs: u32,
+    rhs: u32,
+    expected_lo: u32,
+    expected_hi: u32,
+}
+
+/// Build the smallest program that isolates unsigned `DIVU`.
+///
+/// The program loads the dividend and divisor into `t0` and `t1`, executes `DIVU`, then leaves
+/// the quotient in `LO` and the remainder in `HI`.
+fn divu_program(case: DivuCase) -> Program {
+    let instructions = vec![
+        Instruction::new(Opcode::ADD, Register::T0 as u8, 0, case.lhs, false, true),
+        Instruction::new(Opcode::ADD, Register::T1 as u8, 0, case.rhs, false, true),
+        Instruction::new(
+            Opcode::DIVU,
+            Register::LO as u8,
+            Register::T0 as u32,
+            Register::T1 as u32,
+            false,
+            false,
+        ),
+    ];
+    Program::new(instructions, 0, 0)
+}
+
+/// Regression vectors copied from `mipstest/insttest/src/n45_divu.S`.
+///
+/// These include cases where the quotient is zero, multi-bit quotients, large unsigned dividends,
+/// and the zero-dividend boundary vectors from the end of the assembly test.
+#[test]
+fn n45_divu_vectors() {
+    let cases = [
+        DivuCase {
+            lhs: 0x4e775a80,
+            rhs: 0xb26795ec,
+            expected_lo: 0x00000000,
+            expected_hi: 0x4e775a80,
+        },
+        DivuCase {
+            lhs: 0x4e888700,
+            rhs: 0xf0d84fce,
+            expected_lo: 0x00000000,
+            expected_hi: 0x4e888700,
+        },
+        DivuCase {
+            lhs: 0x01dea048,
+            rhs: 0xf2c74100,
+            expected_lo: 0x00000000,
+            expected_hi: 0x01dea048,
+        },
+        DivuCase {
+            lhs: 0x77e68950,
+            rhs: 0x8b0ddad0,
+            expected_lo: 0x00000000,
+            expected_hi: 0x77e68950,
+        },
+        DivuCase {
+            lhs: 0x72013c68,
+            rhs: 0x48cb8680,
+            expected_lo: 0x00000001,
+            expected_hi: 0x2935b5e8,
+        },
+        DivuCase {
+            lhs: 0x7fb2e9a0,
+            rhs: 0xc9af5700,
+            expected_lo: 0x00000000,
+            expected_hi: 0x7fb2e9a0,
+        },
+        DivuCase {
+            lhs: 0xd7042938,
+            rhs: 0x018a7078,
+            expected_lo: 0x0000008b,
+            expected_hi: 0x00d91810,
+        },
+        DivuCase {
+            lhs: 0xbf81441b,
+            rhs: 0x704e3f24,
+            expected_lo: 0x00000001,
+            expected_hi: 0x4f3304f7,
+        },
+        DivuCase {
+            lhs: 0xeb5994e6,
+            rhs: 0x622f1558,
+            expected_lo: 0x00000002,
+            expected_hi: 0x26fb6a36,
+        },
+        DivuCase {
+            lhs: 0x11176c40,
+            rhs: 0x8128af78,
+            expected_lo: 0x00000000,
+            expected_hi: 0x11176c40,
+        },
+        DivuCase {
+            lhs: 0x32893870,
+            rhs: 0xab09b9c0,
+            expected_lo: 0x00000000,
+            expected_hi: 0x32893870,
+        },
+        DivuCase {
+            lhs: 0x403c60c0,
+            rhs: 0x6fe79f00,
+            expected_lo: 0x00000000,
+            expected_hi: 0x403c60c0,
+        },
+        DivuCase {
+            lhs: 0x00000000,
+            rhs: 0xbea685ab,
+            expected_lo: 0x00000000,
+            expected_hi: 0x00000000,
+        },
+        DivuCase {
+            lhs: 0x00000000,
+            rhs: 0x207ed850,
+            expected_lo: 0x00000000,
+            expected_hi: 0x00000000,
+        },
+        DivuCase {
+            lhs: 0x00000000,
+            rhs: 0x72c14afa,
+            expected_lo: 0x00000000,
+            expected_hi: 0x00000000,
+        },
+        DivuCase {
+            lhs: 0x00000000,
+            rhs: 0xae5365c0,
+            expected_lo: 0x00000000,
+            expected_hi: 0x00000000,
+        },
+        DivuCase {
+            lhs: 0x00000000,
+            rhs: 0x9670f9f0,
+            expected_lo: 0x00000000,
+            expected_hi: 0x00000000,
+        },
+        DivuCase {
+            lhs: 0x00000000,
+            rhs: 0x8e85bf30,
+            expected_lo: 0x00000000,
+            expected_hi: 0x00000000,
+        },
+        DivuCase {
+            lhs: 0x00000000,
+            rhs: 0x11f1eca7,
+            expected_lo: 0x00000000,
+            expected_hi: 0x00000000,
+        },
+    ];
+
+    for (i, case) in cases.into_iter().enumerate() {
+        let mut runtime = Executor::new(divu_program(case), ZKMCoreOpts::default());
+        runtime.run_very_fast().unwrap();
+
+        assert_eq!(runtime.register(Register::T0), case.lhs, "case {i}: DIVU should preserve lhs");
+        assert_eq!(runtime.register(Register::T1), case.rhs, "case {i}: DIVU should preserve rhs");
+        assert_eq!(runtime.register(Register::LO), case.expected_lo, "case {i}: DIVU LO mismatch");
+        assert_eq!(runtime.register(Register::HI), case.expected_hi, "case {i}: DIVU HI mismatch");
+    }
+}

--- a/crates/core/executor/tests/n67_madd.rs
+++ b/crates/core/executor/tests/n67_madd.rs
@@ -1,0 +1,128 @@
+use zkm_core_executor::{Executor, Instruction, Opcode, Program, Register};
+use zkm_stark::ZKMCoreOpts;
+
+#[derive(Clone, Copy, Debug)]
+struct MaddCase {
+    initial_lo: u32,
+    initial_hi: u32,
+    lhs: u32,
+    rhs: u32,
+    expected_lo: u32,
+    expected_hi: u32,
+}
+
+/// Build the smallest program that isolates `MADD`.
+///
+/// The program:
+/// 1. Seeds `LO` and `HI` with the accumulator input from the original mipstest vector.
+/// 2. Loads the multiplicands into `t0` and `t1`.
+/// 3. Executes `MADD t0, t1`, which adds the signed product into the 64-bit `HI:LO` accumulator.
+fn madd_program(case: MaddCase) -> Program {
+    let instructions = vec![
+        Instruction::new(Opcode::ADD, Register::LO as u8, 0, case.initial_lo, false, true),
+        Instruction::new(Opcode::ADD, Register::HI as u8, 0, case.initial_hi, false, true),
+        Instruction::new(Opcode::ADD, Register::T0 as u8, 0, case.lhs, false, true),
+        Instruction::new(Opcode::ADD, Register::T1 as u8, 0, case.rhs, false, true),
+        Instruction::new(
+            Opcode::MADD,
+            Register::LO as u8,
+            Register::T0 as u32,
+            Register::T1 as u32,
+            false,
+            false,
+        ),
+    ];
+    Program::new(instructions, 0, 0)
+}
+
+/// Representative regression vectors copied from `mipstest/insttest/src/n67_madd.S`.
+///
+/// These keep the executor check focused on signed multiply-add semantics with non-trivial initial
+/// `HI:LO` state, rather than trying to duplicate the entire assembly test file here.
+#[test]
+fn n67_madd_vectors() {
+    let cases = [
+        MaddCase {
+            initial_lo: 0x0a7d6700,
+            initial_hi: 0x2668999b,
+            lhs: 0x397b048a,
+            rhs: 0x54a890ae,
+            expected_lo: 0x91381ccc,
+            expected_hi: 0x396ad04f,
+        },
+        MaddCase {
+            initial_lo: 0x2c4ab983,
+            initial_hi: 0x40b6172c,
+            lhs: 0x18948ec7,
+            rhs: 0x309bef68,
+            expected_lo: 0x9c6d835b,
+            expected_hi: 0x4560eae0,
+        },
+        MaddCase {
+            initial_lo: 0x73a03616,
+            initial_hi: 0x48366d2a,
+            lhs: 0x37171000,
+            rhs: 0x72087790,
+            expected_lo: 0xa9093616,
+            expected_hi: 0x60c084bd,
+        },
+        MaddCase {
+            initial_lo: 0x3c346552,
+            initial_hi: 0x343e506b,
+            lhs: 0x3b27039d,
+            rhs: 0x1d702944,
+            expected_lo: 0x8fd58006,
+            expected_hi: 0x3b0ba66e,
+        },
+        MaddCase {
+            initial_lo: 0x2a1d5195,
+            initial_hi: 0x4001710d,
+            lhs: 0x587207ed,
+            rhs: 0x15cff245,
+            expected_lo: 0xa5fa7e76,
+            expected_hi: 0x478aa39b,
+        },
+        MaddCase {
+            initial_lo: 0x3ee63c79,
+            initial_hi: 0x75a97460,
+            lhs: 0x6009cc79,
+            rhs: 0x0792849b,
+            expected_lo: 0x5e456dbc,
+            expected_hi: 0x7880b04d,
+        },
+        MaddCase {
+            initial_lo: 0x0db7cd22,
+            initial_hi: 0x3562eba3,
+            lhs: 0x4d95e8cb,
+            rhs: 0x2244946b,
+            expected_lo: 0xf1e175fb,
+            expected_hi: 0x3fc59d5a,
+        },
+        MaddCase {
+            initial_lo: 0x6bb2429d,
+            initial_hi: 0x522494df,
+            lhs: 0x32ca89cd,
+            rhs: 0x762fa99e,
+            expected_lo: 0x444ea423,
+            expected_hi: 0x6997653a,
+        },
+        MaddCase {
+            initial_lo: 0x788d2e7a,
+            initial_hi: 0x6c458e57,
+            lhs: 0x4ad83a4c,
+            rhs: 0x24d7e7fe,
+            expected_lo: 0x7d8599e2,
+            expected_hi: 0x770b15f6,
+        },
+    ];
+
+    for (i, case) in cases.into_iter().enumerate() {
+        let mut runtime = Executor::new(madd_program(case), ZKMCoreOpts::default());
+        runtime.run_very_fast().unwrap();
+
+        assert_eq!(runtime.register(Register::T0), case.lhs, "case {i}: MADD should preserve lhs");
+        assert_eq!(runtime.register(Register::T1), case.rhs, "case {i}: MADD should preserve rhs");
+        assert_eq!(runtime.register(Register::LO), case.expected_lo, "case {i}: MADD LO mismatch");
+        assert_eq!(runtime.register(Register::HI), case.expected_hi, "case {i}: MADD HI mismatch");
+    }
+}

--- a/crates/core/executor/tests/n68_maddu.rs
+++ b/crates/core/executor/tests/n68_maddu.rs
@@ -1,0 +1,120 @@
+use zkm_core_executor::{Executor, Instruction, Opcode, Program, Register};
+use zkm_stark::ZKMCoreOpts;
+
+#[derive(Clone, Copy, Debug)]
+struct MadduCase {
+    initial_lo: u32,
+    initial_hi: u32,
+    lhs: u32,
+    rhs: u32,
+    expected_lo: u32,
+    expected_hi: u32,
+}
+
+/// Build the smallest program that isolates `MADDU`.
+fn maddu_program(case: MadduCase) -> Program {
+    let instructions = vec![
+        Instruction::new(Opcode::ADD, Register::LO as u8, 0, case.initial_lo, false, true),
+        Instruction::new(Opcode::ADD, Register::HI as u8, 0, case.initial_hi, false, true),
+        Instruction::new(Opcode::ADD, Register::T0 as u8, 0, case.lhs, false, true),
+        Instruction::new(Opcode::ADD, Register::T1 as u8, 0, case.rhs, false, true),
+        Instruction::new(
+            Opcode::MADDU,
+            Register::LO as u8,
+            Register::T0 as u32,
+            Register::T1 as u32,
+            false,
+            false,
+        ),
+    ];
+    Program::new(instructions, 0, 0)
+}
+
+/// Representative regression vectors copied from `mipstest/insttest/src/n68_maddu.S`.
+#[test]
+fn n68_maddu_vectors() {
+    let cases = [
+        MadduCase {
+            initial_lo: 0x73b1491b,
+            initial_hi: 0x71ff0918,
+            lhs: 0x65425edb,
+            rhs: 0x0c9bf6de,
+            expected_lo: 0xbcfefd05,
+            expected_hi: 0x76fbd65f,
+        },
+        MadduCase {
+            initial_lo: 0x2047112c,
+            initial_hi: 0x7ee80821,
+            lhs: 0x0731ad0f,
+            rhs: 0x5335e6d8,
+            expected_lo: 0x84c78fd4,
+            expected_hi: 0x813ea702,
+        },
+        MadduCase {
+            initial_lo: 0x2a5d13d9,
+            initial_hi: 0x7ffa28d0,
+            lhs: 0x3009e9be,
+            rhs: 0x1e8c94cc,
+            expected_lo: 0x454d2f41,
+            expected_hi: 0x85b5b38c,
+        },
+        MadduCase {
+            initial_lo: 0x11090066,
+            initial_hi: 0x48b27be5,
+            lhs: 0x1d78e4f7,
+            rhs: 0x3439632e,
+            expected_lo: 0x444ca9c8,
+            expected_hi: 0x4eb5a5bd,
+        },
+        MadduCase {
+            initial_lo: 0x5e24ba18,
+            initial_hi: 0x77f430c8,
+            lhs: 0x3f6f7613,
+            rhs: 0x40ed4951,
+            expected_lo: 0x48ab811b,
+            expected_hi: 0x880adaa8,
+        },
+        MadduCase {
+            initial_lo: 0x72b428cd,
+            initial_hi: 0x0cc53f61,
+            lhs: 0x43e8ddd9,
+            rhs: 0x010acbba,
+            expected_lo: 0xf54a6b77,
+            expected_hi: 0x0d0c0562,
+        },
+        MadduCase {
+            initial_lo: 0x35b7d2af,
+            initial_hi: 0x1420501e,
+            lhs: 0x285e7267,
+            rhs: 0x47e0c1cf,
+            expected_lo: 0xb975faf8,
+            expected_hi: 0x1f75f30c,
+        },
+        MadduCase {
+            initial_lo: 0x7412502a,
+            initial_hi: 0x64ee20b8,
+            lhs: 0x291fc80c,
+            rhs: 0x67c39946,
+            expected_lo: 0xe6762f72,
+            expected_hi: 0x75995609,
+        },
+        MadduCase {
+            initial_lo: 0x56ed29d0,
+            initial_hi: 0x0e6226e7,
+            lhs: 0x745f9024,
+            rhs: 0x77343afc,
+            expected_lo: 0x8ef73540,
+            expected_hi: 0x44925121,
+        },
+    ];
+
+    for (i, case) in cases.into_iter().enumerate() {
+        let mut runtime = Executor::new(maddu_program(case), ZKMCoreOpts::default());
+        runtime.run_very_fast().unwrap();
+
+        assert_eq!(runtime.register(Register::T0), case.lhs, "case {i}: MADDU should preserve lhs");
+        assert_eq!(runtime.register(Register::T1), case.rhs, "case {i}: MADDU should preserve rhs");
+        assert_eq!(runtime.register(Register::LO), case.expected_lo, "case {i}: MADDU LO mismatch");
+        assert_eq!(runtime.register(Register::HI), case.expected_hi, "case {i}: MADDU HI mismatch");
+    }
+}

--- a/crates/core/executor/tests/n69_msub.rs
+++ b/crates/core/executor/tests/n69_msub.rs
@@ -1,0 +1,120 @@
+use zkm_core_executor::{Executor, Instruction, Opcode, Program, Register};
+use zkm_stark::ZKMCoreOpts;
+
+#[derive(Clone, Copy, Debug)]
+struct MsubCase {
+    initial_lo: u32,
+    initial_hi: u32,
+    lhs: u32,
+    rhs: u32,
+    expected_lo: u32,
+    expected_hi: u32,
+}
+
+/// Build the smallest program that isolates `MSUB`.
+fn msub_program(case: MsubCase) -> Program {
+    let instructions = vec![
+        Instruction::new(Opcode::ADD, Register::LO as u8, 0, case.initial_lo, false, true),
+        Instruction::new(Opcode::ADD, Register::HI as u8, 0, case.initial_hi, false, true),
+        Instruction::new(Opcode::ADD, Register::T0 as u8, 0, case.lhs, false, true),
+        Instruction::new(Opcode::ADD, Register::T1 as u8, 0, case.rhs, false, true),
+        Instruction::new(
+            Opcode::MSUB,
+            Register::LO as u8,
+            Register::T0 as u32,
+            Register::T1 as u32,
+            false,
+            false,
+        ),
+    ];
+    Program::new(instructions, 0, 0)
+}
+
+/// Representative regression vectors copied from `mipstest/insttest/src/n69_msub.S`.
+#[test]
+fn n69_msub_vectors() {
+    let cases = [
+        MsubCase {
+            initial_lo: 0x7c85bcc6,
+            initial_hi: 0x19f7e5ff,
+            lhs: 0x78865b5f,
+            rhs: 0x599f4abd,
+            expected_lo: 0xe3e9d1a3,
+            expected_hi: 0xefc63198,
+        },
+        MsubCase {
+            initial_lo: 0x37ec76ea,
+            initial_hi: 0x0e043668,
+            lhs: 0x559ca251,
+            rhs: 0x6fbcdb0b,
+            expected_lo: 0x38da326f,
+            expected_hi: 0xe8a623bf,
+        },
+        MsubCase {
+            initial_lo: 0x4d923ad9,
+            initial_hi: 0x683cff69,
+            lhs: 0x0951d141,
+            rhs: 0x01a35299,
+            expected_lo: 0x09425900,
+            expected_hi: 0x682dbb7e,
+        },
+        MsubCase {
+            initial_lo: 0x3b647945,
+            initial_hi: 0x6847824b,
+            lhs: 0x3d7013de,
+            rhs: 0x4d93f3e4,
+            expected_lo: 0xf23d0d8d,
+            expected_hi: 0x55a94a6d,
+        },
+        MsubCase {
+            initial_lo: 0x7b12f87a,
+            initial_hi: 0x29806ea5,
+            lhs: 0x69006754,
+            rhs: 0x0c49a091,
+            expected_lo: 0x5a4ff1e6,
+            expected_hi: 0x247636d4,
+        },
+        MsubCase {
+            initial_lo: 0x11c775c0,
+            initial_hi: 0x458d5fa6,
+            lhs: 0x69d32b3f,
+            rhs: 0x1f3849d1,
+            expected_lo: 0x5e443051,
+            expected_hi: 0x38a588b4,
+        },
+        MsubCase {
+            initial_lo: 0x612f23a1,
+            initial_hi: 0x57f24d0a,
+            lhs: 0x247c0390,
+            rhs: 0x12de921a,
+            expected_lo: 0xbbaea701,
+            expected_hi: 0x5541dc6c,
+        },
+        MsubCase {
+            initial_lo: 0x49f30e58,
+            initial_hi: 0x6cb87b7b,
+            lhs: 0x3dd17708,
+            rhs: 0x4678cb1e,
+            expected_lo: 0xf643c368,
+            expected_hi: 0x5bb409b2,
+        },
+        MsubCase {
+            initial_lo: 0x06b0617b,
+            initial_hi: 0x3657d268,
+            lhs: 0x201815dc,
+            rhs: 0x54429c54,
+            expected_lo: 0xfebf254b,
+            expected_hi: 0x2bc7916c,
+        },
+    ];
+
+    for (i, case) in cases.into_iter().enumerate() {
+        let mut runtime = Executor::new(msub_program(case), ZKMCoreOpts::default());
+        runtime.run_very_fast().unwrap();
+
+        assert_eq!(runtime.register(Register::T0), case.lhs, "case {i}: MSUB should preserve lhs");
+        assert_eq!(runtime.register(Register::T1), case.rhs, "case {i}: MSUB should preserve rhs");
+        assert_eq!(runtime.register(Register::LO), case.expected_lo, "case {i}: MSUB LO mismatch");
+        assert_eq!(runtime.register(Register::HI), case.expected_hi, "case {i}: MSUB HI mismatch");
+    }
+}

--- a/crates/core/executor/tests/n70_msubu.rs
+++ b/crates/core/executor/tests/n70_msubu.rs
@@ -1,0 +1,120 @@
+use zkm_core_executor::{Executor, Instruction, Opcode, Program, Register};
+use zkm_stark::ZKMCoreOpts;
+
+#[derive(Clone, Copy, Debug)]
+struct MsubuCase {
+    initial_lo: u32,
+    initial_hi: u32,
+    lhs: u32,
+    rhs: u32,
+    expected_lo: u32,
+    expected_hi: u32,
+}
+
+/// Build the smallest program that isolates `MSUBU`.
+fn msubu_program(case: MsubuCase) -> Program {
+    let instructions = vec![
+        Instruction::new(Opcode::ADD, Register::LO as u8, 0, case.initial_lo, false, true),
+        Instruction::new(Opcode::ADD, Register::HI as u8, 0, case.initial_hi, false, true),
+        Instruction::new(Opcode::ADD, Register::T0 as u8, 0, case.lhs, false, true),
+        Instruction::new(Opcode::ADD, Register::T1 as u8, 0, case.rhs, false, true),
+        Instruction::new(
+            Opcode::MSUBU,
+            Register::LO as u8,
+            Register::T0 as u32,
+            Register::T1 as u32,
+            false,
+            false,
+        ),
+    ];
+    Program::new(instructions, 0, 0)
+}
+
+/// Representative regression vectors copied from `mipstest/insttest/src/n70_msubu.S`.
+#[test]
+fn n70_msubu_vectors() {
+    let cases = [
+        MsubuCase {
+            initial_lo: 0x5452d6af,
+            initial_hi: 0x5fbebdd0,
+            lhs: 0x5d9c545a,
+            rhs: 0x0ae10bc7,
+            expected_lo: 0x311366b9,
+            expected_hi: 0x5bc457d0,
+        },
+        MsubuCase {
+            initial_lo: 0x3ea8ed79,
+            initial_hi: 0x29b2c6ac,
+            lhs: 0x56d5d6f5,
+            rhs: 0x6b83cfa7,
+            expected_lo: 0x49fa98a6,
+            expected_hi: 0x053aaff7,
+        },
+        MsubuCase {
+            initial_lo: 0x2e90e5a0,
+            initial_hi: 0x29382232,
+            lhs: 0x6ca4314e,
+            rhs: 0x45b923e9,
+            expected_lo: 0x33045ba2,
+            expected_hi: 0x0ba14f03,
+        },
+        MsubuCase {
+            initial_lo: 0x2cdae22d,
+            initial_hi: 0x58f3bbfa,
+            lhs: 0x66d5ac3d,
+            rhs: 0x4e233c0e,
+            expected_lo: 0x56762ad7,
+            expected_hi: 0x39907a29,
+        },
+        MsubuCase {
+            initial_lo: 0x0dc8bbc4,
+            initial_hi: 0x0b1895d5,
+            lhs: 0x047970cf,
+            rhs: 0x5cdf31c2,
+            expected_lo: 0xc2d89fe6,
+            expected_hi: 0x09790aa2,
+        },
+        MsubuCase {
+            initial_lo: 0x4ead2a6b,
+            initial_hi: 0x0c2622be,
+            lhs: 0x1ef74e6e,
+            rhs: 0x30a2ddf2,
+            expected_lo: 0x4894106f,
+            expected_hi: 0x064410b1,
+        },
+        MsubuCase {
+            initial_lo: 0x4cc6b886,
+            initial_hi: 0x7239aacc,
+            lhs: 0x5d3e9a76,
+            rhs: 0x2e76e485,
+            expected_lo: 0xb34b6138,
+            expected_hi: 0x614d1cf3,
+        },
+        MsubuCase {
+            initial_lo: 0x4939b078,
+            initial_hi: 0x3ee1b043,
+            lhs: 0x75922c69,
+            rhs: 0x66ab20a0,
+            expected_lo: 0x082dced8,
+            expected_hi: 0x0fbadaf2,
+        },
+        MsubuCase {
+            initial_lo: 0x5ddab2e7,
+            initial_hi: 0x02cd0f9c,
+            lhs: 0x37d476ed,
+            rhs: 0x322d8997,
+            expected_lo: 0x8a3ab81c,
+            expected_hi: 0xf7dba207,
+        },
+    ];
+
+    for (i, case) in cases.into_iter().enumerate() {
+        let mut runtime = Executor::new(msubu_program(case), ZKMCoreOpts::default());
+        runtime.run_very_fast().unwrap();
+
+        assert_eq!(runtime.register(Register::T0), case.lhs, "case {i}: MSUBU should preserve lhs");
+        assert_eq!(runtime.register(Register::T1), case.rhs, "case {i}: MSUBU should preserve rhs");
+        assert_eq!(runtime.register(Register::LO), case.expected_lo, "case {i}: MSUBU LO mismatch");
+        assert_eq!(runtime.register(Register::HI), case.expected_hi, "case {i}: MSUBU HI mismatch");
+    }
+}

--- a/crates/core/executor/tests/n71_seb.rs
+++ b/crates/core/executor/tests/n71_seb.rs
@@ -1,0 +1,56 @@
+use zkm_core_executor::{Executor, Instruction, Opcode, Program, Register};
+use zkm_stark::ZKMCoreOpts;
+
+#[derive(Clone, Copy, Debug)]
+struct SebCase {
+    input: u32,
+    expected: u32,
+}
+
+/// Build the smallest program that isolates `SEB`.
+fn seb_program(input: u32) -> Program {
+    let instructions = vec![
+        Instruction::new(Opcode::ADD, Register::T0 as u8, 0, input, false, true),
+        Instruction::new(Opcode::SEXT, Register::T1 as u8, Register::T0 as u32, 0, false, true),
+    ];
+    Program::new(instructions, 0, 0)
+}
+
+/// Regression vectors copied from `mipstest/insttest/src/n71_seb.S`.
+///
+/// These cover both sign-producing and non-sign-producing low-byte cases, including values where
+/// the upper 24 bits are already non-zero and should be discarded before extension.
+#[test]
+fn n71_seb_vectors() {
+    let cases = [
+        SebCase { input: 0x4e5885b6, expected: 0xffffffb6 },
+        SebCase { input: 0x3296a156, expected: 0x00000056 },
+        SebCase { input: 0x473412a6, expected: 0xffffffa6 },
+        SebCase { input: 0x70aa193f, expected: 0x0000003f },
+        SebCase { input: 0x000000b5, expected: 0xffffffb5 },
+        SebCase { input: 0x0000000d, expected: 0x0000000d },
+        SebCase { input: 0x00000092, expected: 0xffffff92 },
+        SebCase { input: 0x000000ec, expected: 0xffffffec },
+        SebCase { input: 0x00008907, expected: 0x00000007 },
+        SebCase { input: 0x00002e75, expected: 0x00000075 },
+        SebCase { input: 0x000025a7, expected: 0xffffffa7 },
+        SebCase { input: 0x000039b5, expected: 0xffffffb5 },
+    ];
+
+    for (i, case) in cases.into_iter().enumerate() {
+        let mut runtime = Executor::new(seb_program(case.input), ZKMCoreOpts::default());
+        runtime.run_very_fast().unwrap();
+
+        assert_eq!(
+            runtime.register(Register::T0),
+            case.input,
+            "case {i}: SEB should preserve the source"
+        );
+        assert_eq!(
+            runtime.register(Register::T1),
+            case.expected,
+            "case {i}: SEB({:#010x})",
+            case.input
+        );
+    }
+}

--- a/crates/core/executor/tests/n72_seh.rs
+++ b/crates/core/executor/tests/n72_seh.rs
@@ -1,0 +1,60 @@
+use zkm_core_executor::{Executor, Instruction, Opcode, Program, Register};
+use zkm_stark::ZKMCoreOpts;
+
+#[derive(Clone, Copy, Debug)]
+struct SehCase {
+    input: u32,
+    expected: u32,
+}
+
+/// Build the smallest program that isolates `SEH`.
+fn seh_program(input: u32) -> Program {
+    let instructions = vec![
+        Instruction::new(Opcode::ADD, Register::T0 as u8, 0, input, false, true),
+        Instruction::new(Opcode::SEXT, Register::T1 as u8, Register::T0 as u32, 1, false, true),
+    ];
+    Program::new(instructions, 0, 0)
+}
+
+/// Regression vectors copied from `mipstest/insttest/src/n72_seh.S`.
+///
+/// These exercise 16-bit sign extension around the `0x8000` boundary and ensure the high half of
+/// the source word is ignored.
+#[test]
+fn n72_seh_vectors() {
+    let cases = [
+        SehCase { input: 0x75ce8687, expected: 0xffff8687 },
+        SehCase { input: 0x4367c83e, expected: 0xffffc83e },
+        SehCase { input: 0x7b268d2a, expected: 0xffff8d2a },
+        SehCase { input: 0x15044d0d, expected: 0x00004d0d },
+        SehCase { input: 0x00000055, expected: 0x00000055 },
+        SehCase { input: 0x00000088, expected: 0x00000088 },
+        SehCase { input: 0x000000dc, expected: 0x000000dc },
+        SehCase { input: 0x00000009, expected: 0x00000009 },
+        SehCase { input: 0x0000d199, expected: 0xffffd199 },
+        SehCase { input: 0x0000d033, expected: 0xffffd033 },
+        SehCase { input: 0x00006b13, expected: 0x00006b13 },
+        SehCase { input: 0x00006670, expected: 0x00006670 },
+        SehCase { input: 0x00f2020c, expected: 0x0000020c },
+        SehCase { input: 0x00fbabd6, expected: 0xffffabd6 },
+        SehCase { input: 0x00f0eeab, expected: 0xffffeeab },
+        SehCase { input: 0x00f9f413, expected: 0xfffff413 },
+    ];
+
+    for (i, case) in cases.into_iter().enumerate() {
+        let mut runtime = Executor::new(seh_program(case.input), ZKMCoreOpts::default());
+        runtime.run_very_fast().unwrap();
+
+        assert_eq!(
+            runtime.register(Register::T0),
+            case.input,
+            "case {i}: SEH should preserve the source"
+        );
+        assert_eq!(
+            runtime.register(Register::T1),
+            case.expected,
+            "case {i}: SEH({:#010x})",
+            case.input
+        );
+    }
+}

--- a/crates/core/executor/tests/n73_wsbh.rs
+++ b/crates/core/executor/tests/n73_wsbh.rs
@@ -1,0 +1,47 @@
+use zkm_core_executor::{Executor, Instruction, Opcode, Program, Register};
+use zkm_stark::ZKMCoreOpts;
+
+#[derive(Clone, Copy, Debug)]
+struct WsbhCase {
+    input: u32,
+    expected: u32,
+}
+
+/// Build the smallest program that isolates `WSBH`.
+fn wsbh_program(input: u32) -> Program {
+    let instructions = vec![
+        Instruction::new(Opcode::ADD, Register::T0 as u8, 0, input, false, true),
+        Instruction::new(Opcode::WSBH, Register::T1 as u8, Register::T0 as u32, 0, false, true),
+    ];
+    Program::new(instructions, 0, 0)
+}
+
+/// Regression vectors copied from `mipstest/insttest/src/n73_wsbh.S`.
+///
+/// This checks the byte swap within each 16-bit halfword without crossing the halfword boundary.
+#[test]
+fn n73_wsbh_vectors() {
+    let cases = [
+        WsbhCase { input: 0x287b78ef, expected: 0x7b28ef78 },
+        WsbhCase { input: 0x181e0b04, expected: 0x1e18040b },
+        WsbhCase { input: 0x79025ad8, expected: 0x0279d85a },
+        WsbhCase { input: 0x503c59fc, expected: 0x3c50fc59 },
+    ];
+
+    for (i, case) in cases.into_iter().enumerate() {
+        let mut runtime = Executor::new(wsbh_program(case.input), ZKMCoreOpts::default());
+        runtime.run_very_fast().unwrap();
+
+        assert_eq!(
+            runtime.register(Register::T0),
+            case.input,
+            "case {i}: WSBH should preserve the source"
+        );
+        assert_eq!(
+            runtime.register(Register::T1),
+            case.expected,
+            "case {i}: WSBH({:#010x})",
+            case.input
+        );
+    }
+}

--- a/crates/core/executor/tests/n74_ins.rs
+++ b/crates/core/executor/tests/n74_ins.rs
@@ -1,0 +1,207 @@
+use zkm_core_executor::{Executor, Instruction, Opcode, Program, Register};
+use zkm_stark::ZKMCoreOpts;
+
+#[derive(Clone, Copy, Debug)]
+struct InsCase {
+    /// Expected value in the destination register after executing `INS`.
+    expected: u32,
+    /// Source register value whose low `size` bits are inserted.
+    source: u32,
+    /// Initial destination register value before the insertion.
+    initial: u32,
+    /// Least-significant bit position of the insertion window.
+    pos: u32,
+    /// Width of the insertion window in bits.
+    size: u32,
+}
+
+/// Encode the `INS` immediate in the same layout as the instruction stream:
+/// `c = lsb | (msb << 5)`, where `msb = pos + size - 1`.
+fn encode_ins(pos: u32, size: u32) -> u32 {
+    assert!((1..=32).contains(&size));
+    let msb = pos + size - 1;
+    assert!(msb < 32);
+    (msb << 5) | pos
+}
+
+/// Build the smallest program that isolates the `INS` behavior under test.
+///
+/// The program:
+/// 1. Loads the source word into `t0`.
+/// 2. Loads the initial destination word into `t1`.
+/// 3. Executes `INS t1, t0, c`, so the executor updates `t1` while leaving `t0` unchanged.
+fn ins_program(case: InsCase) -> Program {
+    let instructions = vec![
+        // Seed `t0` with the word providing the bits that will be inserted.
+        Instruction::new(Opcode::ADD, Register::T0 as u8, 0, case.source, false, true),
+        // Seed `t1` with the destination word whose selected bit window will be overwritten.
+        Instruction::new(Opcode::ADD, Register::T1 as u8, 0, case.initial, false, true),
+        // Execute the insertion using the encoded `(lsb, msb)` immediate.
+        Instruction::new(
+            Opcode::INS,
+            Register::T1 as u8,
+            Register::T0 as u32,
+            encode_ins(case.pos, case.size),
+            false,
+            true,
+        ),
+    ];
+    Program::new(instructions, 0, 0)
+}
+
+/// Regression vectors copied from `https://github.com/nju-mips/mipstest/blob/master/insttest/src/n74_ins.S`.
+///
+/// These cases exercise plain mid-word insertions as well as boundary conditions:
+/// single-bit inserts, wide inserts, and full-width `pos = 0, size = 32` replacements.
+/// For each vector we check the two observable `INS` semantics that matter here:
+/// - the source register is preserved
+/// - the destination register matches the expected post-insert word
+#[test]
+fn n74_ins_vectors() {
+    let cases = [
+        // Small interior insertion: replace two bits in the middle of the destination word.
+        InsCase { expected: 0x561d90a9, source: 0x7f8ef599, initial: 0x561e90a9, pos: 16, size: 2 },
+        InsCase { expected: 0x38021245, source: 0x358b8480, initial: 0x3a521245, pos: 20, size: 7 },
+        InsCase { expected: 0x27db2103, source: 0x0409f67b, initial: 0x26732103, pos: 19, size: 6 },
+        InsCase { expected: 0x5dde9b56, source: 0x4535b777, initial: 0x5d629b56, pos: 18, size: 8 },
+        InsCase { expected: 0x642229dd, source: 0x32a16e44, initial: 0x6402a9dd, pos: 15, size: 7 },
+        // High-end insertion near the MSB without covering the full top word.
+        InsCase { expected: 0x4a9a8c2b, source: 0x00af69a6, initial: 0x2a9a8c2b, pos: 29, size: 2 },
+        InsCase {
+            expected: 0x1da58354,
+            source: 0x48ec7da5,
+            initial: 0x0e4d8354,
+            pos: 16,
+            size: 13,
+        },
+        // Single-bit insertion at bit 31: checks the top-bit boundary and a no-op outcome.
+        InsCase { expected: 0x07aaee30, source: 0x47969d08, initial: 0x07aaee30, pos: 31, size: 1 },
+        InsCase { expected: 0x28cd46b0, source: 0x5dc97ed9, initial: 0x28cd46b0, pos: 19, size: 1 },
+        InsCase { expected: 0x44afdd07, source: 0x631f58f5, initial: 0x44afdd07, pos: 23, size: 1 },
+        InsCase { expected: 0x50bff56b, source: 0x6b22fe0b, initial: 0x50bff56b, pos: 10, size: 1 },
+        InsCase {
+            expected: 0x2c30671d,
+            source: 0x2e2290c1,
+            initial: 0x2caca71d,
+            pos: 14,
+            size: 13,
+        },
+        InsCase {
+            expected: 0x7a03e9fd,
+            source: 0x10af50fa,
+            initial: 0x7a19b1fd,
+            pos: 10,
+            size: 11,
+        },
+        InsCase { expected: 0x02e54a27, source: 0x24b43e28, initial: 0x02e55a67, pos: 6, size: 8 },
+        InsCase { expected: 0x765b2d76, source: 0x1132ddbb, initial: 0x425b2d76, pos: 25, size: 6 },
+        InsCase { expected: 0x0a06e9b9, source: 0x4a061ba6, initial: 0x0a128fb9, pos: 6, size: 17 },
+        InsCase { expected: 0x32693d59, source: 0x32dfd669, initial: 0x36693d59, pos: 25, size: 2 },
+        InsCase { expected: 0x03406e31, source: 0x7b191a60, initial: 0x03496e31, pos: 15, size: 5 },
+        InsCase {
+            expected: 0x38e70bda,
+            source: 0x5409639c,
+            initial: 0x3ce18bda,
+            pos: 14,
+            size: 14,
+        },
+        InsCase { expected: 0x5b1f97bc, source: 0x698e32f7, initial: 0x5b1f06dc, pos: 3, size: 14 },
+        InsCase { expected: 0x0fb2078d, source: 0x5538b8d9, initial: 0x0fce078d, pos: 17, size: 6 },
+        InsCase {
+            expected: 0x20fa2a57,
+            source: 0x12b361f4,
+            initial: 0x23fe2a57,
+            pos: 15,
+            size: 12,
+        },
+        InsCase { expected: 0x1cd77fa8, source: 0x665957cd, initial: 0x17277fa8, pos: 20, size: 8 },
+        InsCase { expected: 0x1c0ec7da, source: 0x213a0f61, initial: 0x1c9ec7da, pos: 19, size: 5 },
+        // Wide insertion that spans most of the upper word while preserving the low tail.
+        InsCase { expected: 0x100a67cd, source: 0x53080533, initial: 0x1353abcd, pos: 9, size: 22 },
+        InsCase { expected: 0x674193f8, source: 0x169d19fe, initial: 0x674193f8, pos: 31, size: 1 },
+        InsCase { expected: 0xe97205ed, source: 0x24231fd2, initial: 0x4af205ed, pos: 23, size: 9 },
+        InsCase { expected: 0x4fc2655b, source: 0x26110cc9, initial: 0x4fc2655b, pos: 26, size: 1 },
+        InsCase { expected: 0x138b6743, source: 0x5f906ce8, initial: 0x138b154b, pos: 3, size: 15 },
+        InsCase {
+            expected: 0x5cf44f72,
+            source: 0x37893fa2,
+            initial: 0x5cc46f72,
+            pos: 13,
+            size: 11,
+        },
+        InsCase { expected: 0x1f5f78d9, source: 0x73ebef1b, initial: 0x12d9c901, pos: 3, size: 26 },
+        InsCase { expected: 0x26711dd6, source: 0x2f7890db, initial: 0x267118d6, pos: 7, size: 5 },
+        InsCase { expected: 0x5358f976, source: 0x39c4c4a3, initial: 0x5358f970, pos: 1, size: 2 },
+        InsCase { expected: 0x04feeda0, source: 0x3a9a8d68, initial: 0x04feeda0, pos: 27, size: 1 },
+        InsCase { expected: 0x7f0f38d3, source: 0x4ff0f38d, initial: 0x27dace33, pos: 4, size: 27 },
+        InsCase { expected: 0x0e5dd6bf, source: 0x779d338e, initial: 0x745dd6bf, pos: 24, size: 7 },
+        InsCase { expected: 0x66d2829c, source: 0x07e8ec0a, initial: 0x6682829c, pos: 19, size: 4 },
+        InsCase { expected: 0x6f9b7de0, source: 0x4346f20e, initial: 0x5f9b7de0, pos: 28, size: 2 },
+        InsCase { expected: 0x2d51b87f, source: 0x727546e1, initial: 0x2b96cdff, pos: 6, size: 21 },
+        InsCase {
+            expected: 0x3f9b5bed,
+            source: 0x5207e6d6,
+            initial: 0x3598c3ed,
+            pos: 10,
+            size: 18,
+        },
+        InsCase { expected: 0xed10236c, source: 0x08f1bd5d, initial: 0x7510236c, pos: 27, size: 5 },
+        InsCase {
+            expected: 0xb14f110c,
+            source: 0x438c4ac5,
+            initial: 0x7a0f110c,
+            pos: 22,
+            size: 10,
+        },
+        InsCase { expected: 0x93f0009a, source: 0x2249f800, initial: 0x4a00049a, pos: 9, size: 23 },
+        InsCase { expected: 0x028204f0, source: 0x0eb8f805, initial: 0x400204f0, pos: 23, size: 9 },
+        InsCase {
+            expected: 0xb3b10ae9,
+            source: 0x0316cec4,
+            initial: 0x314dcae9,
+            pos: 14,
+            size: 18,
+        },
+        // Near-full-width insertions: keep only the lowest 1/2/3 destination bits.
+        InsCase { expected: 0x15ff759d, source: 0x0affbace, initial: 0x17d04d85, pos: 1, size: 31 },
+        InsCase { expected: 0x29c799ef, source: 0x4a71e67b, initial: 0x5b173f93, pos: 2, size: 30 },
+        InsCase { expected: 0x3e354cc5, source: 0x27c6a998, initial: 0x124a20bd, pos: 3, size: 29 },
+        // Full-width replacement: `INS` should copy the entire source when `pos = 0, size = 32`.
+        InsCase { expected: 0x535d7797, source: 0x535d7797, initial: 0x5ea30063, pos: 0, size: 32 },
+        InsCase {
+            expected: 0x9579b450,
+            source: 0x25655e6d,
+            initial: 0x143bc450,
+            pos: 10,
+            size: 22,
+        },
+        // Same full-width edge case with a different source/destination pair.
+        InsCase { expected: 0x313209e7, source: 0x313209e7, initial: 0x1d2d81ad, pos: 0, size: 32 },
+        // Final top-bit-only insert: another bit-31 boundary case, here also ending as a no-op.
+        InsCase { expected: 0x0d609402, source: 0x64cb2596, initial: 0x0d609402, pos: 31, size: 1 },
+    ];
+
+    for (i, case) in cases.into_iter().enumerate() {
+        // `run_very_fast` is enough for this regression because we are checking executor semantics
+        // only; the proof path is covered separately.
+        let mut runtime = Executor::new(ins_program(case), ZKMCoreOpts::default());
+        runtime.run_very_fast().unwrap();
+
+        // `INS` reads from the source register but should not mutate it.
+        assert_eq!(
+            runtime.register(Register::T0),
+            case.source,
+            "case {i}: INS should not modify the source register",
+        );
+        // The destination register should match the reference result from the original test vector.
+        assert_eq!(
+            runtime.register(Register::T1),
+            case.expected,
+            "case {i}: INS({:#010x}, {:#010x}, pos={}, size={})",
+            case.source,
+            case.initial,
+            case.pos,
+            case.size,
+        );
+    }
+}

--- a/crates/core/executor/tests/n75_ext.rs
+++ b/crates/core/executor/tests/n75_ext.rs
@@ -1,0 +1,115 @@
+use zkm_core_executor::{Executor, Instruction, Opcode, Program, Register};
+use zkm_stark::ZKMCoreOpts;
+
+#[derive(Clone, Copy, Debug)]
+struct ExtCase {
+    expected: u32,
+    source: u32,
+    pos: u32,
+    size: u32,
+}
+
+/// Encode the `EXT` immediate in the executor's internal `(size - 1, lsb)` layout.
+fn encode_ext(pos: u32, size: u32) -> u32 {
+    assert!((1..=32).contains(&size));
+    assert!(pos < 32);
+    assert!(pos + size <= 32);
+    ((size - 1) << 5) | pos
+}
+
+/// Build the smallest program that isolates `EXT`.
+fn ext_program(case: ExtCase) -> Program {
+    let instructions = vec![
+        Instruction::new(Opcode::ADD, Register::T0 as u8, 0, case.source, false, true),
+        Instruction::new(
+            Opcode::EXT,
+            Register::T1 as u8,
+            Register::T0 as u32,
+            encode_ext(case.pos, case.size),
+            false,
+            true,
+        ),
+    ];
+    Program::new(instructions, 0, 0)
+}
+
+/// Regression vectors copied from `mipstest/insttest/src/n75_ext.S`.
+///
+/// These cover single-bit extracts, mid-word windows, and the full-width `pos = 0, size = 32`
+/// case where `EXT` should return the source unchanged.
+#[test]
+fn n75_ext_vectors() {
+    let cases = [
+        ExtCase { expected: 0x00000407, source: 0x101f5494, pos: 18, size: 11 },
+        ExtCase { expected: 0x00000403, source: 0x4386201c, pos: 3, size: 12 },
+        ExtCase { expected: 0x0001c4cb, source: 0x0e2659f8, pos: 11, size: 21 },
+        ExtCase { expected: 0x00000004, source: 0x4ebdcb4b, pos: 28, size: 4 },
+        ExtCase { expected: 0x000007dd, source: 0x4d7dd2b4, pos: 12, size: 12 },
+        ExtCase { expected: 0x00014316, source: 0x2ca18b07, pos: 7, size: 17 },
+        ExtCase { expected: 0x000001fc, source: 0x0fe71482, pos: 19, size: 12 },
+        ExtCase { expected: 0x000001d9, source: 0x04d9fb36, pos: 5, size: 9 },
+        ExtCase { expected: 0x0000034e, source: 0x35c69c97, pos: 9, size: 12 },
+        ExtCase { expected: 0x00001ff0, source: 0x2aefff0c, pos: 4, size: 13 },
+        ExtCase { expected: 0x0000003a, source: 0x3a2662d6, pos: 24, size: 7 },
+        ExtCase { expected: 0x00000181, source: 0x581eb3d0, pos: 20, size: 10 },
+        ExtCase { expected: 0x00000001, source: 0x0ad621d3, pos: 13, size: 3 },
+        ExtCase { expected: 0x00000001, source: 0x6f0b8cb3, pos: 24, size: 1 },
+        ExtCase { expected: 0x00000c85, source: 0x6cc85362, pos: 12, size: 14 },
+        ExtCase { expected: 0x00000000, source: 0x6a25ebf9, pos: 19, size: 2 },
+        ExtCase { expected: 0x00000004, source: 0x013e69cb, pos: 22, size: 8 },
+        ExtCase { expected: 0x00000085, source: 0x63c85094, pos: 12, size: 9 },
+        ExtCase { expected: 0x00000000, source: 0x45a8bb07, pos: 3, size: 5 },
+        ExtCase { expected: 0x00000006, source: 0x29437cd2, pos: 15, size: 3 },
+        ExtCase { expected: 0x00000324, source: 0x4233e48e, pos: 5, size: 10 },
+        ExtCase { expected: 0x000001e6, source: 0x3cc183dc, pos: 21, size: 10 },
+        ExtCase { expected: 0x0000012a, source: 0x3112552e, pos: 9, size: 9 },
+        ExtCase { expected: 0x00000003, source: 0x3dcb0f6a, pos: 28, size: 4 },
+        ExtCase { expected: 0x00000000, source: 0x09f92fc3, pos: 30, size: 1 },
+        ExtCase { expected: 0x00000000, source: 0x5e2d8768, pos: 23, size: 2 },
+        ExtCase { expected: 0x0000000d, source: 0x7ba83e34, pos: 2, size: 4 },
+        ExtCase { expected: 0x00000014, source: 0x0a436673, pos: 23, size: 5 },
+        ExtCase { expected: 0x00000001, source: 0x403a17f7, pos: 30, size: 2 },
+        ExtCase { expected: 0x00002761, source: 0x4ec246e5, pos: 17, size: 14 },
+        ExtCase { expected: 0x00000000, source: 0x7baf1356, pos: 31, size: 1 },
+        ExtCase { expected: 0x00000005, source: 0x571fd1e0, pos: 28, size: 4 },
+        ExtCase { expected: 0x000006a8, source: 0x249aa29f, pos: 10, size: 13 },
+        ExtCase { expected: 0x00000004, source: 0x7245df8a, pos: 20, size: 5 },
+        ExtCase { expected: 0x00000001, source: 0x0edf53ee, pos: 23, size: 2 },
+        ExtCase { expected: 0x00000000, source: 0x47e4d27e, pos: 31, size: 1 },
+        ExtCase { expected: 0x0000013e, source: 0x49f7e641, pos: 19, size: 11 },
+        ExtCase { expected: 0x00000e8e, source: 0x24ffa3bb, pos: 6, size: 12 },
+        ExtCase { expected: 0x00000001, source: 0x5dd60620, pos: 30, size: 1 },
+        ExtCase { expected: 0x05483541, source: 0x2a41aa09, pos: 3, size: 29 },
+        ExtCase { expected: 0x0000001a, source: 0x35328e82, pos: 25, size: 7 },
+        ExtCase { expected: 0x76d3b816, source: 0x76d3b816, pos: 0, size: 32 },
+        ExtCase { expected: 0x00000ccf, source: 0x333da43a, pos: 18, size: 14 },
+        ExtCase { expected: 0x00000006, source: 0x0d35f573, pos: 25, size: 7 },
+        ExtCase { expected: 0x000010eb, source: 0x10eb4cbc, pos: 16, size: 16 },
+        ExtCase { expected: 0x0000250f, source: 0x4a1e2663, pos: 17, size: 15 },
+        ExtCase { expected: 0x00001bf8, source: 0x37f0ab68, pos: 17, size: 15 },
+        ExtCase { expected: 0x00000000, source: 0x61a48528, pos: 31, size: 1 },
+        ExtCase { expected: 0x0020e24c, source: 0x20e24ccf, pos: 8, size: 24 },
+        ExtCase { expected: 0x00001eed, source: 0x3dda5e6d, pos: 17, size: 15 },
+        ExtCase { expected: 0x745a3a5b, source: 0x745a3a5b, pos: 0, size: 32 },
+        ExtCase { expected: 0x00000000, source: 0x3475095d, pos: 31, size: 1 },
+    ];
+
+    for (i, case) in cases.into_iter().enumerate() {
+        let mut runtime = Executor::new(ext_program(case), ZKMCoreOpts::default());
+        runtime.run_very_fast().unwrap();
+
+        assert_eq!(
+            runtime.register(Register::T0),
+            case.source,
+            "case {i}: EXT should preserve the source"
+        );
+        assert_eq!(
+            runtime.register(Register::T1),
+            case.expected,
+            "case {i}: EXT({:#010x}, pos={}, size={})",
+            case.source,
+            case.pos,
+            case.size,
+        );
+    }
+}

--- a/crates/core/executor/tests/n78_rotr.rs
+++ b/crates/core/executor/tests/n78_rotr.rs
@@ -1,0 +1,117 @@
+use zkm_core_executor::{Executor, Instruction, Opcode, Program, Register};
+use zkm_stark::ZKMCoreOpts;
+
+#[derive(Clone, Copy, Debug)]
+struct RotrCase {
+    input: u32,
+    shift: u32,
+    expected: u32,
+}
+
+/// Build the smallest program that isolates `ROTR`.
+fn rotr_program(case: RotrCase) -> Program {
+    let instructions = vec![
+        Instruction::new(Opcode::ADD, Register::T0 as u8, 0, case.input, false, true),
+        Instruction::new(
+            Opcode::ROR,
+            Register::T1 as u8,
+            Register::T0 as u32,
+            case.shift,
+            false,
+            true,
+        ),
+    ];
+    Program::new(instructions, 0, 0)
+}
+
+/// Regression vectors copied from `mipstest/insttest/src/n78_rotr.S`.
+///
+/// The vector list spans every shift count from 0 through 31 so both trivial and wraparound
+/// rotations are covered.
+#[test]
+fn n78_rotr_vectors() {
+    let cases = [
+        RotrCase { input: 0x2078b9d6, shift: 0, expected: 0x2078b9d6 },
+        RotrCase { input: 0x0bfb8d73, shift: 0, expected: 0x0bfb8d73 },
+        RotrCase { input: 0x661ec910, shift: 1, expected: 0x330f6488 },
+        RotrCase { input: 0x10de566c, shift: 1, expected: 0x086f2b36 },
+        RotrCase { input: 0x391c83eb, shift: 2, expected: 0xce4720fa },
+        RotrCase { input: 0x3312df8c, shift: 2, expected: 0x0cc4b7e3 },
+        RotrCase { input: 0x6be66e9b, shift: 3, expected: 0x6d7ccdd3 },
+        RotrCase { input: 0x0df7044a, shift: 3, expected: 0x41bee089 },
+        RotrCase { input: 0x007bf5cd, shift: 4, expected: 0xd007bf5c },
+        RotrCase { input: 0x4a859311, shift: 4, expected: 0x14a85931 },
+        RotrCase { input: 0x3509f9b7, shift: 5, expected: 0xb9a84fcd },
+        RotrCase { input: 0x42c0917d, shift: 5, expected: 0xea16048b },
+        RotrCase { input: 0x6b3e5537, shift: 6, expected: 0xddacf954 },
+        RotrCase { input: 0x390c05ed, shift: 6, expected: 0xb4e43017 },
+        RotrCase { input: 0x101e326d, shift: 7, expected: 0xda203c64 },
+        RotrCase { input: 0x3bc62435, shift: 7, expected: 0x6a778c48 },
+        RotrCase { input: 0x42d2be62, shift: 8, expected: 0x6242d2be },
+        RotrCase { input: 0x772e472e, shift: 8, expected: 0x2e772e47 },
+        RotrCase { input: 0x311a8803, shift: 9, expected: 0x01988d44 },
+        RotrCase { input: 0x47db0f7e, shift: 9, expected: 0xbf23ed87 },
+        RotrCase { input: 0x01185a81, shift: 10, expected: 0xa0404616 },
+        RotrCase { input: 0x5e1bf15f, shift: 10, expected: 0x57d786fc },
+        RotrCase { input: 0x75173ab4, shift: 11, expected: 0x568ea2e7 },
+        RotrCase { input: 0x2a49560d, shift: 11, expected: 0xc1a5492a },
+        RotrCase { input: 0x652c8ed5, shift: 12, expected: 0xed5652c8 },
+        RotrCase { input: 0x4144d2e2, shift: 12, expected: 0x2e24144d },
+        RotrCase { input: 0x767bd46a, shift: 13, expected: 0xa353b3de },
+        RotrCase { input: 0x2b857aba, shift: 13, expected: 0xd5d15c2b },
+        RotrCase { input: 0x43cca916, shift: 14, expected: 0xa4590f32 },
+        RotrCase { input: 0x6bc1dfca, shift: 14, expected: 0x7f29af07 },
+        RotrCase { input: 0x27cebaf6, shift: 15, expected: 0x75ec4f9d },
+        RotrCase { input: 0x644562ed, shift: 15, expected: 0xc5dac88a },
+        RotrCase { input: 0x77bd6d3d, shift: 16, expected: 0x6d3d77bd },
+        RotrCase { input: 0x0ded8406, shift: 16, expected: 0x84060ded },
+        RotrCase { input: 0x7523b959, shift: 17, expected: 0xdcacba91 },
+        RotrCase { input: 0x30d9f128, shift: 17, expected: 0xf894186c },
+        RotrCase { input: 0x41006392, shift: 18, expected: 0x18e49040 },
+        RotrCase { input: 0x610a27f4, shift: 18, expected: 0x89fd1842 },
+        RotrCase { input: 0x3ed0f572, shift: 19, expected: 0x1eae47da },
+        RotrCase { input: 0x417c595f, shift: 19, expected: 0x8b2be82f },
+        RotrCase { input: 0x2b8fbb06, shift: 20, expected: 0xfbb062b8 },
+        RotrCase { input: 0x73daef2a, shift: 20, expected: 0xaef2a73d },
+        RotrCase { input: 0x043ceadc, shift: 21, expected: 0xe756e021 },
+        RotrCase { input: 0x16ce103d, shift: 21, expected: 0x7081e8b6 },
+        RotrCase { input: 0x2ce6f517, shift: 22, expected: 0x9bd45cb3 },
+        RotrCase { input: 0x145b1d49, shift: 22, expected: 0x6c752451 },
+        RotrCase { input: 0x52943472, shift: 23, expected: 0x2868e4a5 },
+        RotrCase { input: 0x6fb9b37a, shift: 23, expected: 0x7366f4df },
+        RotrCase { input: 0x0b896477, shift: 24, expected: 0x8964770b },
+        RotrCase { input: 0x03aebc75, shift: 24, expected: 0xaebc7503 },
+        RotrCase { input: 0x3794c2f8, shift: 25, expected: 0xca617c1b },
+        RotrCase { input: 0x0ca1bef8, shift: 25, expected: 0x50df7c06 },
+        RotrCase { input: 0x61caadd5, shift: 26, expected: 0x72ab7558 },
+        RotrCase { input: 0x2cabfdac, shift: 26, expected: 0x2aff6b0b },
+        RotrCase { input: 0x36eb1505, shift: 27, expected: 0xdd62a0a6 },
+        RotrCase { input: 0x46f73caa, shift: 27, expected: 0xdee79548 },
+        RotrCase { input: 0x6df0d08e, shift: 28, expected: 0xdf0d08e6 },
+        RotrCase { input: 0x2d66e970, shift: 28, expected: 0xd66e9702 },
+        RotrCase { input: 0x727cb764, shift: 29, expected: 0x93e5bb23 },
+        RotrCase { input: 0x31bd79a5, shift: 29, expected: 0x8debcd29 },
+        RotrCase { input: 0x1928c93a, shift: 30, expected: 0x64a324e8 },
+        RotrCase { input: 0x1a4b725a, shift: 30, expected: 0x692dc968 },
+        RotrCase { input: 0x1602dc92, shift: 31, expected: 0x2c05b924 },
+        RotrCase { input: 0x10e63677, shift: 31, expected: 0x21cc6cee },
+    ];
+
+    for (i, case) in cases.into_iter().enumerate() {
+        let mut runtime = Executor::new(rotr_program(case), ZKMCoreOpts::default());
+        runtime.run_very_fast().unwrap();
+
+        assert_eq!(
+            runtime.register(Register::T0),
+            case.input,
+            "case {i}: ROTR should preserve the source"
+        );
+        assert_eq!(
+            runtime.register(Register::T1),
+            case.expected,
+            "case {i}: ROTR({:#010x}, shift={})",
+            case.input,
+            case.shift,
+        );
+    }
+}

--- a/crates/core/executor/tests/n79_rotrv.rs
+++ b/crates/core/executor/tests/n79_rotrv.rs
@@ -1,0 +1,123 @@
+use zkm_core_executor::{Executor, Instruction, Opcode, Program, Register};
+use zkm_stark::ZKMCoreOpts;
+
+#[derive(Clone, Copy, Debug)]
+struct RotrvCase {
+    input: u32,
+    shift: u32,
+    expected: u32,
+}
+
+/// Build the smallest program that isolates `ROTRV`.
+fn rotrv_program(case: RotrvCase) -> Program {
+    let instructions = vec![
+        Instruction::new(Opcode::ADD, Register::T0 as u8, 0, case.input, false, true),
+        Instruction::new(Opcode::ADD, Register::T2 as u8, 0, case.shift, false, true),
+        Instruction::new(
+            Opcode::ROR,
+            Register::T1 as u8,
+            Register::T0 as u32,
+            Register::T2 as u32,
+            false,
+            false,
+        ),
+    ];
+    Program::new(instructions, 0, 0)
+}
+
+/// Regression vectors copied from `mipstest/insttest/src/n79_rotrv.S`.
+///
+/// This mirrors the immediate rotate coverage but routes the shift through a register to ensure
+/// the variable-shift path matches `ROTR`.
+#[test]
+fn n79_rotrv_vectors() {
+    let cases = [
+        RotrvCase { input: 0x33a75dcb, shift: 0, expected: 0x33a75dcb },
+        RotrvCase { input: 0x3c5c2ff1, shift: 0, expected: 0x3c5c2ff1 },
+        RotrvCase { input: 0x54a5ce58, shift: 1, expected: 0x2a52e72c },
+        RotrvCase { input: 0x4329f007, shift: 1, expected: 0xa194f803 },
+        RotrvCase { input: 0x07dff7b7, shift: 2, expected: 0xc1f7fded },
+        RotrvCase { input: 0x37db4cf8, shift: 2, expected: 0x0df6d33e },
+        RotrvCase { input: 0x5356a41d, shift: 3, expected: 0xaa6ad483 },
+        RotrvCase { input: 0x032447bc, shift: 3, expected: 0x806488f7 },
+        RotrvCase { input: 0x44ed49f9, shift: 4, expected: 0x944ed49f },
+        RotrvCase { input: 0x4b32841c, shift: 4, expected: 0xc4b32841 },
+        RotrvCase { input: 0x7de97573, shift: 5, expected: 0x9bef4bab },
+        RotrvCase { input: 0x4b1429b4, shift: 5, expected: 0xa258a14d },
+        RotrvCase { input: 0x43743c2a, shift: 6, expected: 0xa90dd0f0 },
+        RotrvCase { input: 0x41b41f5b, shift: 6, expected: 0x6d06d07d },
+        RotrvCase { input: 0x52c1fb95, shift: 7, expected: 0x2aa583f7 },
+        RotrvCase { input: 0x4cd32714, shift: 7, expected: 0x2899a64e },
+        RotrvCase { input: 0x605e7f06, shift: 8, expected: 0x06605e7f },
+        RotrvCase { input: 0x4563a4de, shift: 8, expected: 0xde4563a4 },
+        RotrvCase { input: 0x66ea1db9, shift: 9, expected: 0xdcb3750e },
+        RotrvCase { input: 0x10a04d73, shift: 9, expected: 0xb9885026 },
+        RotrvCase { input: 0x66845254, shift: 10, expected: 0x9519a114 },
+        RotrvCase { input: 0x5b125631, shift: 10, expected: 0x8c56c495 },
+        RotrvCase { input: 0x73e5eef9, shift: 11, expected: 0xdf2e7cbd },
+        RotrvCase { input: 0x207fb6b3, shift: 11, expected: 0xd6640ff6 },
+        RotrvCase { input: 0x2f5c03d0, shift: 12, expected: 0x3d02f5c0 },
+        RotrvCase { input: 0x68d5d654, shift: 12, expected: 0x65468d5d },
+        RotrvCase { input: 0x2acaa7ed, shift: 13, expected: 0x3f695655 },
+        RotrvCase { input: 0x75240b5c, shift: 13, expected: 0x5ae3a920 },
+        RotrvCase { input: 0x0330c357, shift: 14, expected: 0x0d5c0cc3 },
+        RotrvCase { input: 0x72c3a048, shift: 14, expected: 0x8121cb0e },
+        RotrvCase { input: 0x5a35436f, shift: 15, expected: 0x86deb46a },
+        RotrvCase { input: 0x36d82123, shift: 15, expected: 0x42466db0 },
+        RotrvCase { input: 0x2f1fd039, shift: 16, expected: 0xd0392f1f },
+        RotrvCase { input: 0x2edb11c7, shift: 16, expected: 0x11c72edb },
+        RotrvCase { input: 0x7a02112a, shift: 17, expected: 0x08953d01 },
+        RotrvCase { input: 0x36ffc7f1, shift: 17, expected: 0xe3f89b7f },
+        RotrvCase { input: 0x66b65ebf, shift: 18, expected: 0x97afd9ad },
+        RotrvCase { input: 0x4d58b547, shift: 18, expected: 0x2d51d356 },
+        RotrvCase { input: 0x3a240fad, shift: 19, expected: 0x81f5a744 },
+        RotrvCase { input: 0x2ba3a8b9, shift: 19, expected: 0x75172574 },
+        RotrvCase { input: 0x188b3964, shift: 20, expected: 0xb3964188 },
+        RotrvCase { input: 0x380d8520, shift: 20, expected: 0xd8520380 },
+        RotrvCase { input: 0x76b7d26d, shift: 21, expected: 0xbe936bb5 },
+        RotrvCase { input: 0x5bff758e, shift: 21, expected: 0xfbac72df },
+        RotrvCase { input: 0x79c1a47c, shift: 22, expected: 0x0691f1e7 },
+        RotrvCase { input: 0x4979ce02, shift: 22, expected: 0xe7380925 },
+        RotrvCase { input: 0x28d29ca2, shift: 23, expected: 0xa5394451 },
+        RotrvCase { input: 0x5a202382, shift: 23, expected: 0x404704b4 },
+        RotrvCase { input: 0x0edd72e0, shift: 24, expected: 0xdd72e00e },
+        RotrvCase { input: 0x0fbcba5c, shift: 24, expected: 0xbcba5c0f },
+        RotrvCase { input: 0x6ac070f6, shift: 25, expected: 0x60387b35 },
+        RotrvCase { input: 0x7561c535, shift: 25, expected: 0xb0e29aba },
+        RotrvCase { input: 0x6acf108d, shift: 26, expected: 0xb3c4235a },
+        RotrvCase { input: 0x5ea65fef, shift: 26, expected: 0xa997fbd7 },
+        RotrvCase { input: 0x15e17be8, shift: 27, expected: 0xbc2f7d02 },
+        RotrvCase { input: 0x1a2b145d, shift: 27, expected: 0x45628ba3 },
+        RotrvCase { input: 0x477c3643, shift: 28, expected: 0x77c36434 },
+        RotrvCase { input: 0x40ac23d5, shift: 28, expected: 0x0ac23d54 },
+        RotrvCase { input: 0x0f4f1fb9, shift: 29, expected: 0x7a78fdc8 },
+        RotrvCase { input: 0x4aacf99b, shift: 29, expected: 0x5567ccda },
+        RotrvCase { input: 0x336fc41d, shift: 30, expected: 0xcdbf1074 },
+        RotrvCase { input: 0x69846329, shift: 30, expected: 0xa6118ca5 },
+        RotrvCase { input: 0x01851abe, shift: 31, expected: 0x030a357c },
+        RotrvCase { input: 0x628f9457, shift: 31, expected: 0xc51f28ae },
+    ];
+
+    for (i, case) in cases.into_iter().enumerate() {
+        let mut runtime = Executor::new(rotrv_program(case), ZKMCoreOpts::default());
+        runtime.run_very_fast().unwrap();
+
+        assert_eq!(
+            runtime.register(Register::T0),
+            case.input,
+            "case {i}: ROTRV should preserve the source"
+        );
+        assert_eq!(
+            runtime.register(Register::T2),
+            case.shift,
+            "case {i}: ROTRV should preserve the shift register"
+        );
+        assert_eq!(
+            runtime.register(Register::T1),
+            case.expected,
+            "case {i}: ROTRV({:#010x}, shift={})",
+            case.input,
+            case.shift,
+        );
+    }
+}

--- a/crates/core/executor/tests/n80_clo.rs
+++ b/crates/core/executor/tests/n80_clo.rs
@@ -1,0 +1,108 @@
+use zkm_core_executor::{Executor, Instruction, Opcode, Program, Register};
+use zkm_stark::ZKMCoreOpts;
+
+#[derive(Clone, Copy, Debug)]
+struct CloCase {
+    input: u32,
+    expected: u32,
+}
+
+/// Build the smallest program that isolates `CLO`.
+fn clo_program(input: u32) -> Program {
+    let instructions = vec![
+        Instruction::new(Opcode::ADD, Register::T0 as u8, 0, input, false, true),
+        Instruction::new(Opcode::CLO, Register::T1 as u8, Register::T0 as u32, 0, false, true),
+    ];
+    Program::new(instructions, 0, 0)
+}
+
+/// Regression vectors copied from `mipstest/insttest/src/n80_clo.S`.
+///
+/// These cover the full range from `32` leading ones down to zero, including alternating edge
+/// patterns near the sign bit and values with exactly one leading one.
+#[test]
+fn n80_clo_vectors() {
+    let cases = [
+        CloCase { input: 0xffffffff, expected: 0x00000020 },
+        CloCase { input: 0x6df76b1b, expected: 0x00000000 },
+        CloCase { input: 0xffffffff, expected: 0x00000020 },
+        CloCase { input: 0x71d4858c, expected: 0x00000000 },
+        CloCase { input: 0xfffffffd, expected: 0x0000001e },
+        CloCase { input: 0x2d3733cc, expected: 0x00000000 },
+        CloCase { input: 0xfffffffb, expected: 0x0000001d },
+        CloCase { input: 0x44095238, expected: 0x00000000 },
+        CloCase { input: 0xfffffff9, expected: 0x0000001d },
+        CloCase { input: 0x7a00d5f0, expected: 0x00000000 },
+        CloCase { input: 0xfffffffa, expected: 0x0000001d },
+        CloCase { input: 0x6284ff80, expected: 0x00000000 },
+        CloCase { input: 0xfffffff5, expected: 0x0000001c },
+        CloCase { input: 0x23980b80, expected: 0x00000000 },
+        CloCase { input: 0xffffffea, expected: 0x0000001b },
+        CloCase { input: 0x75f36c00, expected: 0x00000000 },
+        CloCase { input: 0xfffffffe, expected: 0x0000001f },
+        CloCase { input: 0x03a00600, expected: 0x00000000 },
+        CloCase { input: 0xfffffef1, expected: 0x00000017 },
+        CloCase { input: 0x61fa8600, expected: 0x00000000 },
+        CloCase { input: 0xfffffeec, expected: 0x00000017 },
+        CloCase { input: 0x27752000, expected: 0x00000000 },
+        CloCase { input: 0xfffffbb9, expected: 0x00000015 },
+        CloCase { input: 0x40ff0000, expected: 0x00000000 },
+        CloCase { input: 0xfffff29f, expected: 0x00000014 },
+        CloCase { input: 0x770d5000, expected: 0x00000000 },
+        CloCase { input: 0xffffebff, expected: 0x00000013 },
+        CloCase { input: 0x70cee000, expected: 0x00000000 },
+        CloCase { input: 0xffffff47, expected: 0x00000018 },
+        CloCase { input: 0x43288000, expected: 0x00000000 },
+        CloCase { input: 0xffffb591, expected: 0x00000011 },
+        CloCase { input: 0x7c5c0000, expected: 0x00000000 },
+        CloCase { input: 0xfffff10c, expected: 0x00000014 },
+        CloCase { input: 0x5dce0000, expected: 0x00000000 },
+        CloCase { input: 0xffff26db, expected: 0x00000010 },
+        CloCase { input: 0x723c0000, expected: 0x00000000 },
+        CloCase { input: 0xfffde7a6, expected: 0x0000000e },
+        CloCase { input: 0x4f540000, expected: 0x00000000 },
+        CloCase { input: 0xfff9faa9, expected: 0x0000000d },
+        CloCase { input: 0x73680000, expected: 0x00000000 },
+        CloCase { input: 0xfff8cb18, expected: 0x0000000d },
+        CloCase { input: 0x24c00000, expected: 0x00000000 },
+        CloCase { input: 0xfff1b378, expected: 0x0000000c },
+        CloCase { input: 0x64a00000, expected: 0x00000000 },
+        CloCase { input: 0xffe02dbd, expected: 0x0000000b },
+        CloCase { input: 0x40400000, expected: 0x00000000 },
+        CloCase { input: 0xffd35955, expected: 0x0000000a },
+        CloCase { input: 0x5d800000, expected: 0x00000000 },
+        CloCase { input: 0xff0afc07, expected: 0x00000008 },
+        CloCase { input: 0x37000000, expected: 0x00000000 },
+        CloCase { input: 0xfe27acf8, expected: 0x00000007 },
+        CloCase { input: 0x00000000, expected: 0x00000000 },
+        CloCase { input: 0xfd3cbc16, expected: 0x00000006 },
+        CloCase { input: 0x38000000, expected: 0x00000000 },
+        CloCase { input: 0xfd2b72b9, expected: 0x00000006 },
+        CloCase { input: 0x30000000, expected: 0x00000000 },
+        CloCase { input: 0xffb69594, expected: 0x00000009 },
+        CloCase { input: 0x30000000, expected: 0x00000000 },
+        CloCase { input: 0xfeaacc5c, expected: 0x00000007 },
+        CloCase { input: 0x20000000, expected: 0x00000000 },
+        CloCase { input: 0xfeb9bae1, expected: 0x00000007 },
+        CloCase { input: 0x40000000, expected: 0x00000000 },
+        CloCase { input: 0xda2bc144, expected: 0x00000002 },
+        CloCase { input: 0x00000000, expected: 0x00000000 },
+    ];
+
+    for (i, case) in cases.into_iter().enumerate() {
+        let mut runtime = Executor::new(clo_program(case.input), ZKMCoreOpts::default());
+        runtime.run_very_fast().unwrap();
+
+        assert_eq!(
+            runtime.register(Register::T0),
+            case.input,
+            "case {i}: CLO should preserve the source"
+        );
+        assert_eq!(
+            runtime.register(Register::T1),
+            case.expected,
+            "case {i}: CLO({:#010x})",
+            case.input
+        );
+    }
+}

--- a/crates/core/executor/tests/n81_clz.rs
+++ b/crates/core/executor/tests/n81_clz.rs
@@ -1,0 +1,112 @@
+use zkm_core_executor::{Executor, Instruction, Opcode, Program, Register};
+use zkm_stark::ZKMCoreOpts;
+
+#[derive(Clone, Copy, Debug)]
+struct ClzCase {
+    input: u32,
+    expected: u32,
+}
+
+/// Build the smallest program that isolates `CLZ`.
+fn clz_program(input: u32) -> Program {
+    let instructions = vec![
+        Instruction::new(Opcode::ADD, Register::T0 as u8, 0, input, false, true),
+        Instruction::new(Opcode::CLZ, Register::T1 as u8, Register::T0 as u32, 0, false, true),
+    ];
+    Program::new(instructions, 0, 0)
+}
+
+/// Regression vectors copied from `mipstest/insttest/src/n81_clz.S`.
+///
+/// These cover the full range from `32` leading zeros down to zero, including powers of two,
+/// dense mid-word values, and a final top-bit-set case.
+#[test]
+fn n81_clz_vectors() {
+    let cases = [
+        ClzCase { input: 0x00000000, expected: 0x00000020 },
+        ClzCase { input: 0x00000000, expected: 0x00000020 },
+        ClzCase { input: 0x00000000, expected: 0x00000020 },
+        ClzCase { input: 0x00000000, expected: 0x00000020 },
+        ClzCase { input: 0x00000001, expected: 0x0000001f },
+        ClzCase { input: 0x00000000, expected: 0x00000020 },
+        ClzCase { input: 0x00000003, expected: 0x0000001e },
+        ClzCase { input: 0x00000002, expected: 0x0000001e },
+        ClzCase { input: 0x0000000d, expected: 0x0000001c },
+        ClzCase { input: 0x00000006, expected: 0x0000001d },
+        ClzCase { input: 0x00000014, expected: 0x0000001b },
+        ClzCase { input: 0x00000004, expected: 0x0000001d },
+        ClzCase { input: 0x0000003c, expected: 0x0000001a },
+        ClzCase { input: 0x00000039, expected: 0x0000001a },
+        ClzCase { input: 0x00000067, expected: 0x00000019 },
+        ClzCase { input: 0x0000001a, expected: 0x0000001b },
+        ClzCase { input: 0x0000006e, expected: 0x00000019 },
+        ClzCase { input: 0x00000083, expected: 0x00000018 },
+        ClzCase { input: 0x0000018a, expected: 0x00000017 },
+        ClzCase { input: 0x0000014c, expected: 0x00000017 },
+        ClzCase { input: 0x000002eb, expected: 0x00000016 },
+        ClzCase { input: 0x000000bc, expected: 0x00000018 },
+        ClzCase { input: 0x000004dd, expected: 0x00000015 },
+        ClzCase { input: 0x000000a7, expected: 0x00000018 },
+        ClzCase { input: 0x000008dd, expected: 0x00000014 },
+        ClzCase { input: 0x00000113, expected: 0x00000017 },
+        ClzCase { input: 0x00000981, expected: 0x00000014 },
+        ClzCase { input: 0x00001df5, expected: 0x00000013 },
+        ClzCase { input: 0x00002b2a, expected: 0x00000012 },
+        ClzCase { input: 0x0000299f, expected: 0x00000012 },
+        ClzCase { input: 0x00006b9a, expected: 0x00000011 },
+        ClzCase { input: 0x00005740, expected: 0x00000011 },
+        ClzCase { input: 0x0000baf6, expected: 0x00000010 },
+        ClzCase { input: 0x00004f51, expected: 0x00000011 },
+        ClzCase { input: 0x0001197a, expected: 0x0000000f },
+        ClzCase { input: 0x0000731b, expected: 0x00000011 },
+        ClzCase { input: 0x0000fea1, expected: 0x00000010 },
+        ClzCase { input: 0x0003a415, expected: 0x0000000e },
+        ClzCase { input: 0x0004deb6, expected: 0x0000000d },
+        ClzCase { input: 0x00062afe, expected: 0x0000000d },
+        ClzCase { input: 0x0001235b, expected: 0x0000000f },
+        ClzCase { input: 0x0005b54a, expected: 0x0000000d },
+        ClzCase { input: 0x001bb9e2, expected: 0x0000000b },
+        ClzCase { input: 0x0005f6d8, expected: 0x0000000d },
+        ClzCase { input: 0x00235843, expected: 0x0000000a },
+        ClzCase { input: 0x003c18ca, expected: 0x0000000a },
+        ClzCase { input: 0x007ceff2, expected: 0x00000009 },
+        ClzCase { input: 0x0018a8b1, expected: 0x0000000b },
+        ClzCase { input: 0x00bd724d, expected: 0x00000008 },
+        ClzCase { input: 0x0077fb7c, expected: 0x00000009 },
+        ClzCase { input: 0x008fc5fd, expected: 0x00000008 },
+        ClzCase { input: 0x012d0938, expected: 0x00000007 },
+        ClzCase { input: 0x0175ec38, expected: 0x00000007 },
+        ClzCase { input: 0x00dfdada, expected: 0x00000008 },
+        ClzCase { input: 0x0340f1df, expected: 0x00000006 },
+        ClzCase { input: 0x01640515, expected: 0x00000007 },
+        ClzCase { input: 0x082c4bee, expected: 0x00000004 },
+        ClzCase { input: 0x01c0db60, expected: 0x00000007 },
+        ClzCase { input: 0x077fe30a, expected: 0x00000005 },
+        ClzCase { input: 0x0975f718, expected: 0x00000004 },
+        ClzCase { input: 0x0f2584ff, expected: 0x00000004 },
+        ClzCase { input: 0x25f04ea4, expected: 0x00000002 },
+        ClzCase { input: 0x38554e58, expected: 0x00000002 },
+        ClzCase { input: 0x02963ff5, expected: 0x00000006 },
+        ClzCase { input: 0x759e9df5, expected: 0x00000001 },
+        ClzCase { input: 0x27fe67d3, expected: 0x00000002 },
+        ClzCase { input: 0x00000000, expected: 0x00000020 },
+        ClzCase { input: 0xf290b311, expected: 0x00000000 },
+    ];
+
+    for (i, case) in cases.into_iter().enumerate() {
+        let mut runtime = Executor::new(clz_program(case.input), ZKMCoreOpts::default());
+        runtime.run_very_fast().unwrap();
+
+        assert_eq!(
+            runtime.register(Register::T0),
+            case.input,
+            "case {i}: CLZ should preserve the source"
+        );
+        assert_eq!(
+            runtime.register(Register::T1),
+            case.expected,
+            "case {i}: CLZ({:#010x})",
+            case.input
+        );
+    }
+}


### PR DESCRIPTION
@eigmax I started adding tests from `https://github.com/nju-mips/mipstest/` and so far they seem to pass. Right now I just make sure the executor matches what the test expects, but we can also generate a proof and verify it.