### PR TITLE
fix: mul chip trace ffi

### DIFF
--- a/crates/core/machine/cpp/extern.cpp
+++ b/crates/core/machine/cpp/extern.cpp
@@ -121,6 +121,14 @@ extern void shift_right_event_to_row_koalabear(
     shift_right::event_to_row<kb31_t>(*event, *cols_kb31);
 }
 
+extern void mul_event_to_row_koalabear(
+    const CompAluEvent* event,
+    MulCols<KoalaBearP3>* cols
+) {
+    MulCols<kb31_t>* cols_kb31 = reinterpret_cast<MulCols<kb31_t>*>(cols);
+    mul::event_to_row<kb31_t>(*event, *cols_kb31);
+}
+
 extern void div_rem_event_to_row_koalabear(
     const CompAluEvent* event,
     DivRemCols<KoalaBearP3>* cols

--- a/crates/core/machine/include/utils.hpp
+++ b/crates/core/machine/include/utils.hpp
@@ -201,12 +201,14 @@ __ZKM_HOSTDEV__ __ZKM_INLINE__ uint32_t unsigned_abs(int32_t value) {
 
 __ZKM_HOSTDEV__ __ZKM_INLINE__ std::array<uint8_t, 8> signed_extended(const array_t<uint8_t, 4>& value) {
     constexpr uint8_t BYTE_MASK = 0xFF;
-
-    std::array<uint8_t, 8> b_extended;
-    std::copy(value.begin(), value.end(), b_extended.begin());
-
-    std::fill(b_extended.begin() + value.size(), b_extended.end(), BYTE_MASK);
-    return b_extended;
+    std::array<uint8_t, 8> out{};
+    for (size_t i = 0; i < value.size(); ++i) {
+        out[i] = value[i];
+    }
+    for (size_t i = value.size(); i < out.size(); ++i) {
+        out[i] = BYTE_MASK;
+    }
+    return out;
 }
 
 /// Get the system call identifier.

--- a/crates/core/machine/src/alu/add_sub/mod.rs
+++ b/crates/core/machine/src/alu/add_sub/mod.rs
@@ -360,7 +360,7 @@ mod tests {
 
         let chip = AddSubChip::default();
         let trace: RowMajorMatrix<KoalaBear> =
-            chip.generate_trace(shard, &mut ExecutionRecord::default());
+            chip.generate_trace(shard, &mut ExecutionRecord::default()).unwrap();
         let trace_ffi = generate_trace_ffi(shard);
 
         assert_eq!(trace_ffi, trace);
@@ -400,7 +400,7 @@ mod tests {
             rows.extend(row_batch);
         }
 
-        pad_rows_fixed(&mut rows, || [F::ZERO; NUM_ADD_SUB_COLS], None);
+        pad_rows_fixed(&mut rows, || [F::ZERO; NUM_ADD_SUB_COLS], None, "AddSub");
 
         // Convert the trace to a row major matrix.
         RowMajorMatrix::new(rows.into_iter().flatten().collect::<Vec<_>>(), NUM_ADD_SUB_COLS)

--- a/crates/core/machine/src/alu/mul/mod.rs
+++ b/crates/core/machine/src/alu/mul/mod.rs
@@ -189,7 +189,6 @@ impl<F: PrimeField32> MachineAir<F> for MulChip {
         );
 
         // Convert the trace to a row major matrix.
-
         Ok(RowMajorMatrix::new(values, NUM_MUL_COLS))
     }
 
@@ -517,7 +516,6 @@ where
 
 #[cfg(test)]
 mod tests {
-
     use crate::utils::{uni_stark_prove as prove, uni_stark_verify as verify};
     use p3_koala_bear::KoalaBear;
     use p3_matrix::dense::RowMajorMatrix;
@@ -541,6 +539,77 @@ mod tests {
         let chip = MulChip::default();
         let _trace: RowMajorMatrix<KoalaBear> =
             chip.generate_trace(&shard, &mut ExecutionRecord::default()).unwrap();
+    }
+
+    #[cfg(feature = "sys")]
+    #[test]
+    fn test_mul_generate_trace_ffi_eq_rust() {
+        use zkm_core_executor::events::MemoryWriteRecord;
+
+        let mut shard = ExecutionRecord::default();
+        shard.mul_events = vec![CompAluEvent {
+            shard: 5,
+            clk: 790405,
+            pc: 1017624,
+            next_pc: 1017628,
+            opcode: Opcode::MULT,
+            hi: 241306,
+            a: 1298966409,
+            b: 274417,
+            c: 3776743705,
+            hi_record: MemoryWriteRecord {
+                value: 241306,
+                shard: 5,
+                timestamp: 790409,
+                prev_value: 3431,
+                prev_shard: 5,
+                prev_timestamp: 790387,
+            },
+            hi_record_is_real: true,
+        }];
+
+        let chip = MulChip::default();
+        let trace: RowMajorMatrix<KoalaBear> =
+            chip.generate_trace(&shard, &mut ExecutionRecord::default()).unwrap();
+        let trace_ffi = generate_trace_ffi(&shard);
+
+        assert_eq!(trace_ffi, trace);
+    }
+
+    #[cfg(feature = "sys")]
+    fn generate_trace_ffi(input: &ExecutionRecord) -> RowMajorMatrix<KoalaBear> {
+        use super::{MulCols, NUM_MUL_COLS};
+        use crate::utils::next_power_of_two;
+        use crate::utils::zeroed_f_vec;
+        use p3_koala_bear::KoalaBear;
+        use p3_maybe_rayon::prelude::{ParallelBridge, ParallelIterator};
+        use std::borrow::BorrowMut;
+
+        type F = KoalaBear;
+
+        let padded_nb_rows = next_power_of_two(input.mul_events.len(), None, "Mul");
+        let mut values = zeroed_f_vec(padded_nb_rows * NUM_MUL_COLS);
+        let nb_rows = input.mul_events.len();
+        let chunk_size = std::cmp::max((nb_rows + 1) / num_cpus::get(), 1);
+
+        values.chunks_mut(chunk_size * NUM_MUL_COLS).enumerate().par_bridge().for_each(
+            |(i, rows)| {
+                rows.chunks_mut(NUM_MUL_COLS).enumerate().for_each(|(j, row)| {
+                    let idx = i * chunk_size + j;
+                    let cols: &mut MulCols<F> = row.borrow_mut();
+
+                    if idx < nb_rows {
+                        let event = &input.mul_events[idx];
+                        unsafe {
+                            crate::sys::mul_event_to_row_koalabear(event, cols);
+                        }
+                    }
+                });
+            },
+        );
+
+        // Convert the trace to a row major matrix.
+        RowMajorMatrix::new(values, NUM_MUL_COLS)
     }
 
     #[test]

--- a/crates/core/machine/src/cpu/trace.rs
+++ b/crates/core/machine/src/cpu/trace.rs
@@ -309,7 +309,7 @@ mod tests {
 
         let chip = CpuChip::default();
         let trace: RowMajorMatrix<KoalaBear> =
-            chip.generate_trace(&shard, &mut ExecutionRecord::default());
+            chip.generate_trace(&shard, &mut ExecutionRecord::default()).unwrap();
         let trace_ffi = generate_trace_ffi(&shard);
 
         assert_eq!(trace_ffi, trace);

--- a/crates/core/machine/src/memory/local.rs
+++ b/crates/core/machine/src/memory/local.rs
@@ -416,7 +416,7 @@ mod tests {
         let record = get_test_execution_record();
         let chip = MemoryLocalChip::new();
         let trace: RowMajorMatrix<KoalaBear> =
-            chip.generate_trace(&record, &mut ExecutionRecord::default());
+            chip.generate_trace(&record, &mut ExecutionRecord::default()).unwrap();
         let trace_ffi = generate_trace_ffi(&record, trace.height());
 
         assert_eq!(trace_ffi, trace);


### PR DESCRIPTION
Issue: std::copy fails on device due to missing `__device__` support, while std::fill works or its effects come from pre-initialized memory.
Solution: Proposing a manual loop-based copy and fill in signed_extended using fixed sizes to ensure device compatibility.