### PR TITLE
handling keccak and poseidon hash with the picus extractor

### DIFF
--- a/crates/core/machine/src/air/memory.rs
+++ b/crates/core/machine/src/air/memory.rs
@@ -4,7 +4,7 @@ use p3_air::AirBuilder;
 use p3_field::FieldAlgebra;
 use zkm_core_executor::ByteOpcode;
 use zkm_stark::{
-    air::{AirLookup, BaseAirBuilder, ByteAirBuilder, LookupScope},
+    air::{AirLookup, BaseAirBuilder, ByteAirBuilder, LookupScope, OperationSummaryAirBuilder},
     LookupKind,
 };
 
@@ -22,7 +22,9 @@ pub trait MemoryAirBuilder: BaseAirBuilder {
         addr: impl Into<Self::Expr>,
         memory_access: &impl MemoryCols<E>,
         do_check: impl Into<Self::Expr>,
-    ) {
+    ) where
+        Self: OperationSummaryAirBuilder,
+    {
         let do_check: Self::Expr = do_check.into();
         let shard: Self::Expr = shard.into();
         let clk: Self::Expr = clk.into();
@@ -69,7 +71,9 @@ pub trait MemoryAirBuilder: BaseAirBuilder {
         initial_addr: impl Into<Self::Expr> + Clone,
         memory_access_slice: &[impl MemoryCols<E>],
         verify_memory_access: impl Into<Self::Expr> + Copy,
-    ) {
+    ) where
+        Self: OperationSummaryAirBuilder,
+    {
         for (i, access_slice) in memory_access_slice.iter().enumerate() {
             self.eval_memory_access(
                 shard,
@@ -93,24 +97,40 @@ pub trait MemoryAirBuilder: BaseAirBuilder {
         do_check: impl Into<Self::Expr>,
         shard: impl Into<Self::Expr> + Clone,
         clk: impl Into<Self::Expr>,
-    ) {
+    ) where
+        Self: OperationSummaryAirBuilder,
+    {
         let do_check: Self::Expr = do_check.into();
         let compare_clk: Self::Expr = mem_access.compare_clk.clone().into();
         let shard: Self::Expr = shard.clone().into();
         let prev_shard: Self::Expr = mem_access.prev_shard.clone().into();
+        let prev_clk: Self::Expr = mem_access.prev_clk.clone().into();
+        let clk: Self::Expr = clk.into();
+        let diff_16bit_limb: Self::Expr = mem_access.diff_16bit_limb.clone().into();
+        let diff_8bit_limb: Self::Expr = mem_access.diff_8bit_limb.clone().into();
+
+        if self.try_emit_memory_timestamp_summary(
+            do_check.clone(),
+            shard.clone(),
+            clk.clone(),
+            prev_shard.clone(),
+            prev_clk.clone(),
+            compare_clk.clone(),
+            diff_16bit_limb.clone(),
+            diff_8bit_limb.clone(),
+        ) {
+            return;
+        }
 
         // First verify that compare_clk's value is correct.
         self.when(do_check.clone()).assert_bool(compare_clk.clone());
         self.when(do_check.clone()).when(compare_clk.clone()).assert_eq(shard.clone(), prev_shard);
 
         // Get the comparison timestamp values for the current and previous memory access.
-        let prev_comp_value = self.if_else(
-            mem_access.compare_clk.clone(),
-            mem_access.prev_clk.clone(),
-            mem_access.prev_shard.clone(),
-        );
+        let prev_comp_value =
+            self.if_else(mem_access.compare_clk.clone(), prev_clk, mem_access.prev_shard.clone());
 
-        let current_comp_val = self.if_else(compare_clk.clone(), clk.into(), shard.clone());
+        let current_comp_val = self.if_else(compare_clk.clone(), clk, shard.clone());
 
         // Assert `current_comp_val > prev_comp_val`. We check this by asserting that
         // `0 <= current_comp_val-prev_comp_val-1 < 2^24`.
@@ -125,12 +145,7 @@ pub trait MemoryAirBuilder: BaseAirBuilder {
 
         // Verify that mem_access.ts_diff = mem_access.ts_diff_16bit_limb
         // + mem_access.ts_diff_8bit_limb * 2^16.
-        self.eval_range_check_24bits(
-            diff_minus_one,
-            mem_access.diff_16bit_limb.clone(),
-            mem_access.diff_8bit_limb.clone(),
-            do_check,
-        );
+        self.eval_range_check_24bits(diff_minus_one, diff_16bit_limb, diff_8bit_limb, do_check);
     }
 
     /// Verifies the inputted value is within 24 bits.

--- a/crates/core/machine/src/operations/koala_bear_word.rs
+++ b/crates/core/machine/src/operations/koala_bear_word.rs
@@ -48,7 +48,7 @@ impl<F: Field> KoalaBearWordRangeChecker<F> {
             self.and_most_sig_byte_decomp_0_to_6 * self.most_sig_byte_decomp[6];
     }
 
-    pub fn range_check<AB: ZKMAirBuilder>(
+    fn range_check_exact<AB: ZKMAirBuilder>(
         builder: &mut AB,
         value: Word<AB::Var>,
         cols: KoalaBearWordRangeChecker<AB::Var>,
@@ -102,5 +102,21 @@ impl<F: Field> KoalaBearWordRangeChecker<F> {
             .when(is_real)
             .when(cols.and_most_sig_byte_decomp_0_to_7)
             .assert_zero(value[0] + value[1] + value[2]);
+    }
+
+    pub fn range_check<AB: ZKMAirBuilder>(
+        builder: &mut AB,
+        value: Word<AB::Var>,
+        cols: KoalaBearWordRangeChecker<AB::Var>,
+        is_real: AB::Expr,
+    ) {
+        if builder.try_emit_koala_bear_word_range_summary(
+            value.map(|limb| AB::Expr::zero() + limb),
+            is_real.clone(),
+        ) {
+            return;
+        }
+
+        Self::range_check_exact(builder, value, cols, is_real);
     }
 }

--- a/crates/core/machine/src/operations/poseidon2/air.rs
+++ b/crates/core/machine/src/operations/poseidon2/air.rs
@@ -1,13 +1,16 @@
-use std::array;
+use std::{array, mem::size_of};
 
 use p3_air::PairBuilder;
 use p3_field::{FieldAlgebra, PrimeField32};
 use p3_koala_bear::KoalaBear;
 use p3_poseidon2::matmul_internal;
 use zkm_primitives::RC_16_30_U32;
-use zkm_stark::air::MachineAirBuilder;
+use zkm_stark::air::{MachineAirBuilder, OperationSummaryAirBuilder};
 
-use super::{permutation::Poseidon2Cols, NUM_EXTERNAL_ROUNDS, NUM_INTERNAL_ROUNDS, WIDTH};
+use super::{
+    permutation::{permutation, Poseidon2Cols, Poseidon2Degree3Cols, Poseidon2Degree3Projection},
+    NUM_EXTERNAL_ROUNDS, NUM_INTERNAL_ROUNDS, WIDTH,
+};
 
 const INTERNAL_DIAG_MONTY_16: [KoalaBear; 16] = KoalaBear::new_array([
     KoalaBear::ORDER_U32 - 2,
@@ -155,4 +158,46 @@ where
     for i in 0..WIDTH {
         builder.assert_eq(external_state[i], state[i].clone())
     }
+}
+
+/// Evaluate the degree-3 Poseidon2 permutation, optionally replacing the exact
+/// inlined constraints with a semantic projected submodule.
+///
+/// The projected interface exposes only the caller-visible permutation
+/// boundary:
+/// - input: the first external-round state
+/// - output: the final permutation state
+///
+/// All intermediate round-state and S-box witness columns remain existential
+/// inside the submodule.
+pub fn eval_degree3<AB>(builder: &mut AB, local_row: &dyn Poseidon2Cols<AB::Var>)
+where
+    AB: MachineAirBuilder + PairBuilder + OperationSummaryAirBuilder,
+{
+    let current_inputs: Vec<AB::Expr> =
+        local_row.external_rounds_state()[0].iter().map(|value| (*value).into()).collect();
+    let current_outputs: Vec<AB::Expr> =
+        local_row.perm_output().iter().map(|value| (*value).into()).collect();
+
+    if builder.try_emit_projected_summary(
+        "Poseidon2Degree3Permutation",
+        &Poseidon2Degree3Projection::picus_projection_info(),
+        &current_inputs,
+        &current_outputs,
+        size_of::<Poseidon2Degree3Cols<u8>>(),
+        |builder, source_row| {
+            let projected = permutation::<_, 3>(source_row);
+            for r in 0..NUM_EXTERNAL_ROUNDS {
+                eval_external_round(builder, projected.as_ref(), r);
+            }
+            eval_internal_rounds(builder, projected.as_ref());
+        },
+    ) {
+        return;
+    }
+
+    for r in 0..NUM_EXTERNAL_ROUNDS {
+        eval_external_round(builder, local_row, r);
+    }
+    eval_internal_rounds(builder, local_row);
 }

--- a/crates/core/machine/src/operations/poseidon2/permutation.rs
+++ b/crates/core/machine/src/operations/poseidon2/permutation.rs
@@ -4,7 +4,7 @@ use std::{
     mem::size_of,
 };
 
-use zkm_derive::AlignedBorrow;
+use zkm_derive::{AlignedBorrow, PicusProjection};
 
 use crate::operations::poseidon2::{NUM_EXTERNAL_ROUNDS, NUM_INTERNAL_ROUNDS, WIDTH};
 use crate::utils::indices_arr;
@@ -43,6 +43,28 @@ const fn make_col_map_degree9() -> Poseidon2Degree9Cols<usize> {
 pub struct Poseidon2Degree3Cols<T: Copy> {
     pub state: Poseidon2StateCols<T>,
     pub sbox_state: Poseidon2SBoxCols<T>,
+}
+
+/// Semantic Picus projection for the observable input/output contract of the
+/// degree-3 Poseidon2 permutation witness.
+///
+/// The full witness layout contains many intermediate round columns that are
+/// internal to the permutation and should remain existential when Poseidon2 is
+/// eventually emitted as an operation-level submodule. This projection keeps
+/// only the caller-visible boundary:
+/// - `state_in`: the first external-round state
+/// - `state_out`: the final permutation output
+///
+/// Projection `path = ...` points at the semantic source slice. The projected
+/// field type determines the width, while the derive recursively takes the
+/// first source column from the path.
+#[derive(PicusProjection)]
+#[picus_projection(source = Poseidon2Degree3Cols<u8>, col_map = POSEIDON2_DEGREE3_COL_MAP)]
+pub struct Poseidon2Degree3Projection {
+    #[picus(input, path = state.external_rounds_state[0])]
+    pub state_in: [u8; WIDTH],
+    #[picus(output, path = state.output_state)]
+    pub state_out: [u8; WIDTH],
 }
 
 /// A column layout for a poseidon2 permutation with degree 9 constraints.

--- a/crates/core/machine/src/syscall/precompiles/keccak_sponge/air.rs
+++ b/crates/core/machine/src/syscall/precompiles/keccak_sponge/air.rs
@@ -2,7 +2,7 @@ use crate::air::{MemoryAirBuilder, WordAirBuilder};
 use crate::memory::MemoryCols;
 use crate::operations::XorOperation;
 use crate::syscall::precompiles::keccak_sponge::columns::{
-    KeccakSpongeCols, NUM_KECCAK_SPONGE_COLS,
+    KeccakPermutationProjection, KeccakSpongeCols, NUM_KECCAK_SPONGE_COLS,
 };
 use crate::syscall::precompiles::keccak_sponge::{
     KeccakSpongeChip, KECCAK_GENERAL_OUTPUT_U32S, KECCAK_GENERAL_RATE_U32S, KECCAK_STATE_U32S,
@@ -104,14 +104,81 @@ where
             next.input_address - AB::Expr::from_canonical_u32(KECCAK_GENERAL_RATE_U32S as u32 * 4),
         );
 
-        // Eval the plonky3 keccak air
-        let mut sub_builder =
-            SubAirBuilder::<AB, KeccakAir, AB::Var>::new(builder, 0..NUM_KECCAK_COLS);
-        self.p3_keccak.eval(&mut sub_builder);
+        // Eval the plonky3 keccak air. Picus can hide the full sub-AIR behind a
+        // semantic boundary; other builders continue to inline the exact
+        // `SubAirBuilder` path.
+        let current_inputs = self.keccak_summary_inputs::<AB>(local);
+        let current_outputs = self.keccak_summary_outputs::<AB>(local);
+        if !builder.try_emit_hidden_subair_summary(
+            "KeccakAir",
+            &KeccakPermutationProjection::picus_projection_info(),
+            &current_inputs,
+            &current_outputs,
+            NUM_KECCAK_COLS,
+            false,
+            |nested_builder| self.p3_keccak.eval(nested_builder),
+        ) {
+            let mut sub_builder =
+                SubAirBuilder::<AB, KeccakAir, AB::Var>::new(builder, 0..NUM_KECCAK_COLS);
+            self.p3_keccak.eval(&mut sub_builder);
+        }
     }
 }
 
 impl KeccakSpongeChip {
+    /// Flatten the visible Keccak-f input state from the embedded sub-AIR.
+    ///
+    /// The surrounding sponge AIR ties these lanes to memory/original-state
+    /// data, so they must remain visible caller inputs even when the full
+    /// Keccak round system is summarized as a hidden submodule.
+    fn keccak_summary_inputs<AB: ZKMAirBuilder>(
+        &self,
+        local: &KeccakSpongeCols<AB::Var>,
+    ) -> Vec<AB::Expr> {
+        let mut inputs = Vec::with_capacity(25 * U64_LIMBS);
+        for y in 0..5 {
+            for x in 0..5 {
+                for limb in 0..U64_LIMBS {
+                    inputs.push(local.keccak.a[y][x][limb].into());
+                }
+            }
+        }
+        inputs
+    }
+
+    /// Flatten the caller-visible outputs of the embedded Keccak-f sub-AIR.
+    ///
+    /// The sponge AIR depends on the round-position flags as well as the
+    /// post-round `A'''` state. The `(0, 0)` lane is stored separately from the
+    /// remaining 24 lanes, so the flattened order mirrors the projection
+    /// metadata exactly:
+    /// 1. `first_step`
+    /// 2. `final_step`
+    /// 3. `A'''[0, 0]`
+    /// 4. the remaining 24 `A'''` lanes in witness layout order
+    fn keccak_summary_outputs<AB: ZKMAirBuilder>(
+        &self,
+        local: &KeccakSpongeCols<AB::Var>,
+    ) -> Vec<AB::Expr> {
+        let mut outputs = Vec::with_capacity(2 + 25 * U64_LIMBS);
+        outputs.push(local.keccak.step_flags[0].into());
+        outputs.push(local.keccak.step_flags[NUM_ROUNDS - 1].into());
+        for limb in 0..U64_LIMBS {
+            outputs.push(local.keccak.a_prime_prime_prime(0, 0, limb).into());
+        }
+        for y in 0..5 {
+            for x in 0..5 {
+                if y == 0 && x == 0 {
+                    continue;
+                }
+                for limb in 0..U64_LIMBS {
+                    outputs.push(local.keccak.a_prime_prime_prime(y, x, limb).into());
+                }
+            }
+        }
+        outputs
+    }
+
     fn eval_flags<AB: ZKMAirBuilder>(&self, builder: &mut AB, local: &KeccakSpongeCols<AB::Var>) {
         let first_block = local.is_first_input_block;
         let final_block = local.is_final_input_block;

--- a/crates/core/machine/src/syscall/precompiles/keccak_sponge/columns.rs
+++ b/crates/core/machine/src/syscall/precompiles/keccak_sponge/columns.rs
@@ -1,18 +1,19 @@
-use core::mem::size_of;
+use core::mem::{size_of, transmute};
 
 use crate::memory::{MemoryReadCols, MemoryWriteCols};
 use crate::operations::XorOperation;
 use crate::syscall::precompiles::keccak_sponge::{
     KECCAK_GENERAL_OUTPUT_U32S, KECCAK_GENERAL_RATE_U32S, KECCAK_STATE_U32S,
 };
+use crate::utils::indices_arr;
 
-use p3_keccak_air::KeccakCols;
-use zkm_derive::AlignedBorrow;
-use zkm_stark::Word;
+use p3_keccak_air::{KeccakCols, NUM_KECCAK_COLS, U64_LIMBS};
+use zkm_derive::{AlignedBorrow, PicusAnnotations, PicusProjection};
+use zkm_stark::{PicusInfo, Word};
 
 /// KeccakSpongeCols is the column layout for the keccak sponge.
 /// The number of rows equal to the number of block.
-#[derive(AlignedBorrow)]
+#[derive(AlignedBorrow, PicusAnnotations)]
 #[repr(C)]
 pub(crate) struct KeccakSpongeCols<T> {
     pub keccak: KeccakCols<T>,
@@ -37,3 +38,50 @@ pub(crate) struct KeccakSpongeCols<T> {
 }
 
 pub const NUM_KECCAK_SPONGE_COLS: usize = size_of::<KeccakSpongeCols<u8>>();
+
+#[allow(dead_code)]
+/// The full Keccak-f state is 25 lanes, each stored as 4 u16 limbs.
+pub const KECCAK_STATE_LIMBS: usize = 25 * U64_LIMBS;
+#[allow(dead_code)]
+/// The witness stores the final `(0, 0)` lane after iota in a dedicated field.
+/// The remaining 24 lanes stay in `a_prime_prime`, so the semantic output
+/// boundary needs a tail slice for those lanes.
+pub const KECCAK_STATE_TAIL_LIMBS: usize = KECCAK_STATE_LIMBS - U64_LIMBS;
+
+#[allow(dead_code)]
+pub const KECCAK_PICUS_COL_MAP: KeccakCols<usize> = make_keccak_picus_col_map();
+
+#[allow(dead_code)]
+const fn make_keccak_picus_col_map() -> KeccakCols<usize> {
+    let indices_arr = indices_arr::<NUM_KECCAK_COLS>();
+    unsafe { transmute::<[usize; NUM_KECCAK_COLS], KeccakCols<usize>>(indices_arr) }
+}
+
+/// Semantic Picus projection for the observable input/output contract of the
+/// embedded Keccak-f permutation witness.
+///
+/// The full witness stores many intermediate round columns that should remain
+/// internal to any future Keccak operation submodule. The semantic boundary is:
+/// - `state_in`: the full 25-lane permutation input state
+/// - `first_step` / `final_step`: the caller-visible round-position flags
+/// - `state_out_0_0`: the `(0, 0)` output lane after iota
+/// - `state_out_rest`: the remaining 24 output lanes
+///
+/// The output is split because the witness layout stores the `(0, 0)` lane in
+/// `a_prime_prime_prime_0_0_limbs`, while the other 24 lanes remain in
+/// `a_prime_prime`.
+#[allow(dead_code)]
+#[derive(PicusProjection)]
+#[picus_projection(source = KeccakCols<u8>, col_map = KECCAK_PICUS_COL_MAP)]
+pub struct KeccakPermutationProjection {
+    #[picus(input, path = a)]
+    pub state_in: [[[u8; U64_LIMBS]; 5]; 5],
+    #[picus(output, path = step_flags[0])]
+    pub first_step: u8,
+    #[picus(output, path = step_flags[23])]
+    pub final_step: u8,
+    #[picus(output, path = a_prime_prime_prime_0_0_limbs)]
+    pub state_out_0_0: [u8; U64_LIMBS],
+    #[picus(output, path = a_prime_prime[0][1])]
+    pub state_out_rest: [u8; KECCAK_STATE_TAIL_LIMBS],
+}

--- a/crates/core/machine/src/syscall/precompiles/keccak_sponge/trace.rs
+++ b/crates/core/machine/src/syscall/precompiles/keccak_sponge/trace.rs
@@ -29,6 +29,10 @@ impl<F: PrimeField32> MachineAir<F> for KeccakSpongeChip {
         "KeccakSponge".to_string()
     }
 
+    fn picus_info(&self) -> zkm_stark::PicusInfo {
+        KeccakSpongeCols::<u8>::picus_info()
+    }
+
     fn generate_dependencies(
         &self,
         input: &Self::Record,

--- a/crates/core/machine/src/syscall/precompiles/poseidon2/air.rs
+++ b/crates/core/machine/src/syscall/precompiles/poseidon2/air.rs
@@ -4,9 +4,9 @@ use p3_air::{Air, AirBuilder, BaseAir, PairBuilder};
 use p3_field::FieldAlgebra;
 use p3_matrix::Matrix;
 
-use crate::operations::poseidon2::air::{eval_external_round, eval_internal_rounds};
+use crate::operations::poseidon2::air::eval_degree3;
 use crate::operations::poseidon2::permutation::Poseidon2Cols;
-use crate::operations::poseidon2::{NUM_EXTERNAL_ROUNDS, WIDTH};
+use crate::operations::poseidon2::WIDTH;
 use crate::operations::KoalaBearWordRangeChecker;
 use crate::syscall::precompiles::poseidon2::{
     columns::{Poseidon2MemCols, NUM_COLS},
@@ -58,10 +58,7 @@ where
         }
 
         // Constrain the permutation.
-        for r in 0..NUM_EXTERNAL_ROUNDS {
-            eval_external_round(builder, &local.poseidon2.permutation, r);
-        }
-        eval_internal_rounds(builder, &local.poseidon2.permutation);
+        eval_degree3(builder, &local.poseidon2.permutation);
 
         for i in 0..WIDTH {
             // Range check the current value of the state in memory. This ensures that each part

--- a/crates/derive/src/lib.rs
+++ b/crates/derive/src/lib.rs
@@ -401,6 +401,11 @@ fn find_eval_trait_bound(attrs: &[syn::Attribute]) -> Option<String> {
     None
 }
 
+#[proc_macro_derive(PicusProjection, attributes(picus, picus_projection))]
+pub fn picus_projection_derive(input: TokenStream) -> TokenStream {
+    picus_annotations::picus_projection_derive(input)
+}
+
 #[proc_macro_derive(PicusAnnotations, attributes(picus))]
 pub fn picus_annotations_derive(input: TokenStream) -> TokenStream {
     picus_annotations::picus_annotations_derive(input)

--- a/crates/derive/src/picus_annotations.rs
+++ b/crates/derive/src/picus_annotations.rs
@@ -10,13 +10,14 @@ use syn::{
     GenericArgument, Path, PathArguments, Result, Token, Type, TypeArray, TypeReference, TypeSlice,
 };
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Clone)]
 struct PicusArgs {
     input: bool,
     output: bool,
     transition_input: bool,
     transition_output: bool,
     selector: bool,
+    path: Option<syn::Expr>,
 }
 
 enum Arg {
@@ -25,6 +26,7 @@ enum Arg {
     TransitionInput,
     TransitionOutput,
     Selector,
+    Path(syn::Expr),
 }
 
 impl Parse for Arg {
@@ -49,6 +51,10 @@ impl Parse for Arg {
         if is("selector") {
             return Ok(Arg::Selector);
         }
+        if is("path") {
+            input.parse::<Token![=]>()?;
+            return Ok(Arg::Path(input.parse()?));
+        }
 
         Err(syn::Error::new_spanned(key, "unknown key in #[picus(...)]"))
     }
@@ -69,9 +75,75 @@ fn parse_picus_attr(attr: &syn::Attribute) -> syn::Result<Option<PicusArgs>> {
             Arg::TransitionInput => out.transition_input = true,
             Arg::TransitionOutput => out.transition_output = true,
             Arg::Selector => out.selector = true,
+            Arg::Path(expr) => out.path = Some(expr),
         }
     }
     Ok(Some(out))
+}
+
+#[derive(Clone)]
+struct ProjectionStructArgs {
+    source: Type,
+    col_map: syn::Expr,
+}
+
+enum ProjectionStructArg {
+    Source(Type),
+    ColMap(syn::Expr),
+}
+
+impl Parse for ProjectionStructArg {
+    fn parse(input: ParseStream<'_>) -> Result<Self> {
+        let key: Path = input.parse()?;
+        if key.is_ident("source") {
+            input.parse::<Token![=]>()?;
+            return Ok(Self::Source(input.parse()?));
+        }
+        if key.is_ident("col_map") {
+            input.parse::<Token![=]>()?;
+            return Ok(Self::ColMap(input.parse()?));
+        }
+        Err(syn::Error::new_spanned(key, "unknown key in #[picus_projection(...)]"))
+    }
+}
+
+fn parse_picus_projection_attr(
+    attrs: &[syn::Attribute],
+) -> syn::Result<Option<ProjectionStructArgs>> {
+    let mut source: Option<Type> = None;
+    let mut col_map: Option<syn::Expr> = None;
+    let mut found = false;
+    for attr in attrs {
+        if !attr.path.is_ident("picus_projection") {
+            continue;
+        }
+        found = true;
+        let items =
+            attr.parse_args_with(Punctuated::<ProjectionStructArg, Token![,]>::parse_terminated)?;
+        for it in items {
+            match it {
+                ProjectionStructArg::Source(ty) => source = Some(ty),
+                ProjectionStructArg::ColMap(expr) => col_map = Some(expr),
+            }
+        }
+    }
+
+    if !found {
+        return Ok(None);
+    }
+    let source = source.ok_or_else(|| {
+        syn::Error::new(
+            proc_macro2::Span::call_site(),
+            "missing `source = ...` in #[picus_projection(...)]",
+        )
+    })?;
+    let col_map = col_map.ok_or_else(|| {
+        syn::Error::new(
+            proc_macro2::Span::call_site(),
+            "missing `col_map = ...` in #[picus_projection(...)]",
+        )
+    })?;
+    Ok(Some(ProjectionStructArgs { source, col_map }))
 }
 
 // ---------- type substitution: replace the primary column element type with `u8` ----------
@@ -309,6 +381,135 @@ pub fn picus_annotations_derive(input: TokenStream) -> TokenStream {
             pub fn picus_info() -> PicusInfo {
                 let mut info = PicusInfo::default();
                 let mut cur: usize = 0; // 1 column == 1 byte
+                #(#steps)*
+                info
+            }
+        }
+    };
+    expanded.into()
+}
+
+pub fn picus_projection_derive(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let ident = input.ident.clone();
+    let generics = input.generics.clone();
+    let where_clause = &generics.where_clause;
+    let (impl_generics, ty_generics, _) = generics.split_for_impl();
+
+    let struct_args = match parse_picus_projection_attr(&input.attrs) {
+        Ok(Some(args)) => args,
+        Ok(None) => {
+            return syn::Error::new_spanned(
+                &input,
+                "PicusProjection requires #[picus_projection(source = ..., col_map = ...)]",
+            )
+            .to_compile_error()
+            .into()
+        }
+        Err(e) => return e.to_compile_error().into(),
+    };
+
+    let data = match &input.data {
+        syn::Data::Struct(s) => s,
+        _ => {
+            return syn::Error::new_spanned(&input, "PicusProjection only supports structs")
+                .to_compile_error()
+                .into()
+        }
+    };
+    let fields = match &data.fields {
+        syn::Fields::Named(f) => &f.named,
+        _ => {
+            return syn::Error::new_spanned(&input, "PicusProjection requires named fields")
+                .to_compile_error()
+                .into()
+        }
+    };
+
+    let source_ty = struct_args.source;
+    let col_map = struct_args.col_map;
+
+    let mut steps = Vec::new();
+    for field in fields.iter() {
+        let f_ident = field.ident.as_ref().unwrap();
+        let f_name = f_ident.to_string();
+
+        let mut flags = PicusArgs::default();
+        for attr in &field.attrs {
+            if attr.path.is_ident("picus") {
+                match parse_picus_attr(attr) {
+                    Ok(Some(a)) => {
+                        flags.input |= a.input;
+                        flags.output |= a.output;
+                        flags.transition_input |= a.transition_input;
+                        flags.transition_output |= a.transition_output;
+                        flags.selector |= a.selector;
+                        if let Some(path) = a.path {
+                            flags.path = Some(path);
+                        }
+                    }
+                    Ok(None) => {}
+                    Err(e) => return e.to_compile_error().into(),
+                }
+            }
+        }
+
+        if flags.transition_input || flags.transition_output || flags.selector {
+            return syn::Error::new_spanned(
+                field,
+                "PicusProjection fields currently support only #[picus(input, ...)] and #[picus(output, ...)]",
+            )
+            .to_compile_error()
+            .into();
+        }
+        if !flags.input && !flags.output {
+            return syn::Error::new_spanned(
+                field,
+                "PicusProjection fields must be marked with #[picus(input, path = ...)] or #[picus(output, path = ...)]",
+            )
+            .to_compile_error()
+            .into();
+        }
+        let Some(path_expr) = flags.path.clone() else {
+            return syn::Error::new_spanned(
+                field,
+                "PicusProjection fields require `path = ...` to identify the source slice",
+            )
+            .to_compile_error()
+            .into();
+        };
+
+        let field_ty = &field.ty;
+        let push_in = if flags.input {
+            quote! { info.input_ranges.push((start, end, #f_name.to_string())); }
+        } else {
+            quote!()
+        };
+        let push_out = if flags.output {
+            quote! { info.output_ranges.push((start, end, #f_name.to_string())); }
+        } else {
+            quote!()
+        };
+
+        steps.push(quote! {{
+            let start: usize =
+                zkm_stark::PicusProjectionStart::projection_start(&((#col_map).#path_expr));
+            let width: usize = ::core::mem::size_of::<#field_ty>();
+            let end = start + width;
+            info.name_to_colrange.insert(#f_name.to_string(), (start, end));
+            for x in start..end {
+                info.col_to_name.insert(x, format!("{}_{}", #f_name, x));
+            }
+            #push_in
+            #push_out
+        }});
+    }
+
+    let expanded = quote! {
+        impl #impl_generics #ident #ty_generics #where_clause {
+            pub fn picus_projection_info() -> zkm_stark::PicusProjectionInfo {
+                let mut info = zkm_stark::PicusProjectionInfo::default();
+                let _ = ::core::mem::size_of::<#source_ty>();
                 #(#steps)*
                 info
             }

--- a/crates/picus/README.md
+++ b/crates/picus/README.md
@@ -93,6 +93,125 @@ Concrete example:
   immediate next row's `delta` / `checks` as outputs in the phases where successor
   state is part of the interface.
 
+## Picus Projections
+
+`PicusAnnotations` describe concrete trace storage fields on a chip row.
+`PicusProjection` is different: it describes a smaller semantic interface
+projected out of a larger witness layout.
+
+This is useful when a submodule has many internal witness columns, but Picus
+should expose only the semantically relevant boundary to the caller. Typical
+examples are operation summaries such as Poseidon2 or embedded sub-AIRs such as
+Keccak.
+
+Use a projection when:
+
+- the full witness layout is too large or too internal to expose directly,
+- the caller should see only a specific input/output contract,
+- the remaining witness columns should stay existential inside the summarized
+  submodule.
+
+Do not use a projection as a replacement for `PicusAnnotations` on the chip's
+main trace columns. Projections are for operation/submodule boundaries, not for
+describing ordinary chip row I/O.
+
+### Derive shape
+
+Projection metadata is declared on a separate struct with:
+
+- `#[derive(PicusProjection)]`
+- a struct-level `#[picus_projection(source = ..., col_map = ...)]`
+- field-level `#[picus(input, path = ...)]` / `#[picus(output, path = ...)]`
+
+Example:
+
+```rust
+use zkm_derive::PicusProjection;
+
+#[derive(PicusProjection)]
+#[picus_projection(
+    source = Poseidon2Degree3Cols<u8>,
+    col_map = POSEIDON2_DEGREE3_COL_MAP
+)]
+pub struct Poseidon2Degree3Projection {
+    #[picus(input, path = state.external_rounds_state[0])]
+    pub state_in: [u8; WIDTH],
+
+    #[picus(output, path = state.output_state)]
+    pub state_out: [u8; WIDTH],
+}
+```
+
+This does not change the witness layout. It only says:
+
+- the semantic input starts at `state.external_rounds_state[0]` and spans
+  `WIDTH` columns,
+- the semantic output starts at `state.output_state` and spans `WIDTH` columns.
+
+### How `path` works
+
+`path = ...` points at the source slice inside the `col_map`.
+
+Important detail:
+
+- `path` selects the start of the semantic slice,
+- the projected field type determines the width,
+- the derive recursively takes the first concrete source column from the path.
+
+So this:
+
+```rust
+#[picus(input, path = state.external_rounds_state[0])]
+pub state_in: [u8; WIDTH],
+```
+
+means:
+
+- start at the first column of `state.external_rounds_state[0]`,
+- take `WIDTH` consecutive columns.
+
+You do not need to write `state.external_rounds_state[0][0]` unless you really
+want to refer to a scalar source column.
+
+### Column map requirement
+
+The `col_map` argument should be a `usize`-instantiated version of the source
+layout whose fields hold concrete column indices.
+
+For example:
+
+```rust
+pub const POSEIDON2_DEGREE3_COL_MAP: Poseidon2Degree3Cols<usize> = make_col_map_degree3();
+```
+
+This lets the derive resolve `path = ...` into concrete source ranges without
+changing the actual runtime trace type.
+
+### Intended usage in Picus
+
+Today projections are consumed by summary hooks in `OperationSummaryAirBuilder`,
+not by ordinary chip extraction.
+
+The supported pattern is:
+
+1. Keep the full exact AIR/witness layout unchanged.
+2. Define a projection for the caller-visible semantic boundary.
+3. Use a Picus summary hook to emit an auxiliary module whose interface is the
+   projected inputs/outputs.
+4. Keep the rest of the source witness internal to that auxiliary module.
+
+That is how Picus can summarize a large operation while preserving exact
+internal constraints.
+
+### Rule of thumb
+
+- Use `PicusAnnotations` for concrete chip row metadata.
+- Use `PicusProjection` for summarized operation or sub-AIR boundaries.
+- Keep projections semantic and minimal: expose only what the caller should
+  reason about.
+- Leave intermediate round state, helper witnesses, and existential internals
+  out of the projection unless they are part of the intended contract.
+
 ## OpcodeSpec
 
 `OpcodeSpec` defines how instruction lookups are routed during extraction.

--- a/crates/picus/src/picus_builder.rs
+++ b/crates/picus/src/picus_builder.rs
@@ -374,6 +374,34 @@ impl<'chips, A: MachineAir<Felt>> PicusBuilder<'chips, A> {
         self.picus_module.calls.push(call);
     }
 
+    fn flatten_projection_ranges(
+        source_row: &[PicusAtom],
+        ranges: &[(usize, usize, String)],
+    ) -> Vec<PicusExpr> {
+        let mut exprs = Vec::new();
+        for (start, end, _) in ranges {
+            assert!(*start <= *end && *end <= source_row.len());
+            for col_idx in *start..*end {
+                exprs.push(source_row[col_idx].into());
+            }
+        }
+        exprs
+    }
+
+    fn bind_projection_ports(
+        module: &mut PicusModule,
+        ports: &[PicusExpr],
+        source_exprs: &[PicusExpr],
+    ) {
+        assert_eq!(ports.len(), source_exprs.len());
+        for (port, source_expr) in ports.iter().zip(source_exprs) {
+            Self::push_constraint_into(
+                module,
+                PicusConstraint::new_equality(port.clone(), source_expr.clone()),
+            );
+        }
+    }
+
     fn add_guarded_constraint(&mut self, is_real: PicusExpr, constraint: PicusConstraint) {
         match is_real {
             PicusExpr::Const(0) => {}
@@ -1434,6 +1462,302 @@ impl<'chips, A: MachineAir<Felt>> OperationSummaryAirBuilder for PicusBuilder<'c
             is_real,
             PicusConstraint::new_equality(result, is_lower_half_zero * is_upper_half_zero),
         );
+        true
+    }
+
+    fn try_emit_koala_bear_word_range_summary(
+        &mut self,
+        input: Word<Self::Expr>,
+        is_real: Self::Expr,
+    ) -> bool {
+        // This is the exact semantic collapse of the current AIR in
+        // `KoalaBearWordRangeChecker`:
+        // - the most-significant byte must be < 128
+        // - if that byte is exactly 127, the lower three limbs must sum to 0
+        //
+        // Intentionally, this does not add byte constraints for the lower
+        // three limbs because the exact AIR does not prove them here.
+        self.add_guarded_constraint(
+            is_real.clone(),
+            PicusConstraint::new_leq(input[3].clone(), 127.into()),
+        );
+        self.add_guarded_constraint(
+            is_real,
+            PicusConstraint::Implies(
+                Box::new(PicusConstraint::new_equality(input[3].clone(), PicusExpr::Const(127))),
+                Box::new(PicusConstraint::new_equality(
+                    input[0].clone() + input[1].clone() + input[2].clone(),
+                    PicusExpr::Const(0),
+                )),
+            ),
+        );
+        true
+    }
+
+    fn try_emit_memory_timestamp_summary(
+        &mut self,
+        do_check: Self::Expr,
+        shard: Self::Expr,
+        clk: Self::Expr,
+        prev_shard: Self::Expr,
+        prev_clk: Self::Expr,
+        compare_clk: Self::Expr,
+        diff_16bit_limb: Self::Expr,
+        diff_8bit_limb: Self::Expr,
+    ) -> bool {
+        let module_name = "MemoryTimestampCheck".to_string();
+        if !self.aux_modules.contains_key(&module_name) {
+            // Picus currently requires every helper module to expose at least
+            // one output. This checker is semantically output-free, so we add a
+            // single dummy result and constrain it to the constant 0.
+            let mut timestamp_module = PicusModule::build_empty(module_name.clone(), 8, 1);
+            let do_check = timestamp_module.inputs[0].clone();
+            let shard = timestamp_module.inputs[1].clone();
+            let clk = timestamp_module.inputs[2].clone();
+            let prev_shard = timestamp_module.inputs[3].clone();
+            let prev_clk = timestamp_module.inputs[4].clone();
+            let compare_clk = timestamp_module.inputs[5].clone();
+            let diff_16bit_limb = timestamp_module.inputs[6].clone();
+            let diff_8bit_limb = timestamp_module.inputs[7].clone();
+            let dummy_output = timestamp_module.outputs[0].clone();
+
+            // Keep the synthetic output fixed so the helper remains a pure
+            // checker module from the caller's perspective.
+            Self::push_constraint_into(
+                &mut timestamp_module,
+                PicusConstraint::new_equality(dummy_output, PicusExpr::Const(0)),
+            );
+
+            // Exact `eval_memory_access_timestamp` semantics:
+            // - compare_clk is a guarded bit
+            // - if compare_clk = 1, we compare clks within the same shard
+            // - otherwise we compare shard indices
+            // - diff limbs form a guarded 24-bit decomposition of
+            //   current_comp - prev_comp - 1
+            Self::push_constraint_into(
+                &mut timestamp_module,
+                PicusConstraint::new_bit(compare_clk.clone()).apply_multiplier(do_check.clone()),
+            );
+            Self::push_constraint_into(
+                &mut timestamp_module,
+                PicusConstraint::new_equality(shard.clone(), prev_shard.clone())
+                    .apply_multiplier(do_check.clone() * compare_clk.clone()),
+            );
+
+            let prev_comp_value = compare_clk.clone() * prev_clk.clone()
+                + (PicusExpr::Const(1) - compare_clk.clone()) * prev_shard.clone();
+            let current_comp_value = compare_clk.clone() * clk.clone()
+                + (PicusExpr::Const(1) - compare_clk.clone()) * shard.clone();
+            let diff_minus_one = current_comp_value - prev_comp_value - PicusExpr::Const(1);
+
+            Self::push_constraint_into(
+                &mut timestamp_module,
+                PicusConstraint::new_equality(
+                    diff_minus_one,
+                    diff_16bit_limb.clone() + diff_8bit_limb.clone() * PicusExpr::Const(1 << 16),
+                )
+                .apply_multiplier(do_check.clone()),
+            );
+            Self::push_constraint_into(
+                &mut timestamp_module,
+                PicusConstraint::new_leq(diff_16bit_limb, PicusExpr::Const(65535))
+                    .apply_multiplier(do_check.clone()),
+            );
+            Self::push_constraint_into(
+                &mut timestamp_module,
+                PicusConstraint::new_leq(diff_8bit_limb, PicusExpr::Const(255))
+                    .apply_multiplier(do_check.clone()),
+            );
+
+            self.aux_modules.insert(module_name.clone(), timestamp_module);
+        }
+
+        let dummy_output = fresh_picus_expr();
+        self.push_call(PicusCall::new(
+            module_name,
+            &[dummy_output],
+            &[
+                do_check,
+                shard,
+                clk,
+                prev_shard,
+                prev_clk,
+                compare_clk,
+                diff_16bit_limb,
+                diff_8bit_limb,
+            ],
+        ));
+        true
+    }
+
+    fn try_emit_projected_summary<F>(
+        &mut self,
+        module_name: &str,
+        projection_info: &zkm_stark::PicusProjectionInfo,
+        current_inputs: &[Self::Expr],
+        current_outputs: &[Self::Expr],
+        source_width: usize,
+        build_exact: F,
+    ) -> bool
+    where
+        F: FnOnce(&mut Self, &[Self::Var]),
+    {
+        let projected_input_len: usize =
+            projection_info.input_ranges.iter().map(|(start, end, _)| end - start).sum();
+        let projected_output_len: usize =
+            projection_info.output_ranges.iter().map(|(start, end, _)| end - start).sum();
+        assert_eq!(current_inputs.len(), projected_input_len);
+        assert_eq!(current_outputs.len(), projected_output_len);
+
+        if !self.aux_modules.contains_key(module_name) {
+            let mut hidden_source_row = Vec::with_capacity(source_width);
+            for _ in 0..source_width {
+                hidden_source_row.push(fresh_picus_var());
+            }
+
+            let mut nested_module = PicusModule::build_empty(
+                module_name.to_string(),
+                current_inputs.len(),
+                current_outputs.len(),
+            );
+            let projected_source_inputs =
+                Self::flatten_projection_ranges(&hidden_source_row, &projection_info.input_ranges);
+            let projected_source_outputs =
+                Self::flatten_projection_ranges(&hidden_source_row, &projection_info.output_ranges);
+            let formal_inputs = nested_module.inputs.clone();
+            let formal_outputs = nested_module.outputs.clone();
+            Self::bind_projection_ports(
+                &mut nested_module,
+                &formal_inputs,
+                &projected_source_inputs,
+            );
+            Self::bind_projection_ports(
+                &mut nested_module,
+                &formal_outputs,
+                &projected_source_outputs,
+            );
+
+            let mut nested_builder = PicusBuilder {
+                preprocessed: self.preprocessed.clone(),
+                main: self.main.clone(),
+                public_values: self.public_values.clone(),
+                picus_module: nested_module,
+                global_send_outputs: Vec::new(),
+                aux_modules: BTreeMap::new(),
+                chips: self.chips,
+                extract_modularly: self.extract_modularly,
+                submodule_mode: self.submodule_mode,
+                shr_carry_summary_mode: self.shr_carry_summary_mode,
+                phase: self.phase,
+                local_only: self.local_only,
+                capture_interface: false,
+                specialization_env: BTreeMap::new(),
+                concrete_pending_tasks: Vec::new(),
+                symbolic_pending_tasks: Vec::new(),
+            };
+
+            build_exact(&mut nested_builder, &hidden_source_row);
+
+            for (name, module) in nested_builder.aux_modules {
+                self.aux_modules.entry(name).or_insert(module);
+            }
+            self.aux_modules.entry(module_name.to_string()).or_insert(nested_builder.picus_module);
+        }
+
+        self.push_call(PicusCall::new(module_name.to_string(), current_outputs, current_inputs));
+        true
+    }
+
+    /// Emit an auxiliary module for an exact sub-AIR whose internal witness
+    /// spans multiple phase rows.
+    ///
+    /// This mirrors `try_emit_projected_summary`, but instead of hiding a
+    /// single source row it hides a full phase-shaped trace matrix. The caller
+    /// still sees only the projected semantic boundary from the hidden local
+    /// row; all other hidden rows remain existential to the nested module.
+    fn try_emit_hidden_subair_summary<F>(
+        &mut self,
+        module_name: &str,
+        projection_info: &zkm_stark::PicusProjectionInfo,
+        current_inputs: &[Self::Expr],
+        current_outputs: &[Self::Expr],
+        source_width: usize,
+        source_local_only: bool,
+        build_exact: F,
+    ) -> bool
+    where
+        F: FnOnce(&mut Self),
+    {
+        let projected_input_len: usize =
+            projection_info.input_ranges.iter().map(|(start, end, _)| end - start).sum();
+        let projected_output_len: usize =
+            projection_info.output_ranges.iter().map(|(start, end, _)| end - start).sum();
+        assert_eq!(current_inputs.len(), projected_input_len);
+        assert_eq!(current_outputs.len(), projected_output_len);
+
+        if !self.aux_modules.contains_key(module_name) {
+            let row_count = self.phase.row_count(source_local_only);
+            let mut hidden_main = Vec::with_capacity(source_width * row_count);
+            for _ in 0..(source_width * row_count) {
+                hidden_main.push(fresh_picus_var());
+            }
+            // Projections are interpreted against the hidden local row. Any
+            // successor rows exist solely so the nested exact AIR can witness
+            // its own `next`-row constraints.
+            let hidden_local_row = hidden_main[..source_width].to_vec();
+
+            let mut nested_module = PicusModule::build_empty(
+                module_name.to_string(),
+                current_inputs.len(),
+                current_outputs.len(),
+            );
+            let projected_source_inputs =
+                Self::flatten_projection_ranges(&hidden_local_row, &projection_info.input_ranges);
+            let projected_source_outputs =
+                Self::flatten_projection_ranges(&hidden_local_row, &projection_info.output_ranges);
+            let formal_inputs = nested_module.inputs.clone();
+            let formal_outputs = nested_module.outputs.clone();
+            Self::bind_projection_ports(
+                &mut nested_module,
+                &formal_inputs,
+                &projected_source_inputs,
+            );
+            Self::bind_projection_ports(
+                &mut nested_module,
+                &formal_outputs,
+                &projected_source_outputs,
+            );
+
+            let mut nested_builder = PicusBuilder {
+                preprocessed: self.preprocessed.clone(),
+                main: RowMajorMatrix::new(hidden_main, source_width),
+                public_values: self.public_values.clone(),
+                picus_module: nested_module,
+                global_send_outputs: Vec::new(),
+                aux_modules: BTreeMap::new(),
+                chips: self.chips,
+                extract_modularly: self.extract_modularly,
+                submodule_mode: self.submodule_mode,
+                shr_carry_summary_mode: self.shr_carry_summary_mode,
+                phase: self.phase,
+                local_only: source_local_only,
+                capture_interface: false,
+                specialization_env: BTreeMap::new(),
+                concrete_pending_tasks: Vec::new(),
+                symbolic_pending_tasks: Vec::new(),
+            };
+
+            // Populate the nested module with the original exact sub-AIR over
+            // the hidden phase-shaped witness matrix.
+            build_exact(&mut nested_builder);
+
+            for (name, module) in nested_builder.aux_modules {
+                self.aux_modules.entry(name).or_insert(module);
+            }
+            self.aux_modules.entry(module_name.to_string()).or_insert(nested_builder.picus_module);
+        }
+
+        self.push_call(PicusCall::new(module_name.to_string(), current_outputs, current_inputs));
         true
     }
 }

--- a/crates/stark/src/air/builder.rs
+++ b/crates/stark/src/air/builder.rs
@@ -208,6 +208,109 @@ pub trait OperationSummaryAirBuilder: AirBuilder {
     ) -> bool {
         false
     }
+
+    /// Optional hook for replacing the exact `KoalaBearWordRangeChecker` AIR
+    /// with an equivalent semantic summary.
+    ///
+    /// This summary should preserve the current operation semantics only. In
+    /// particular, it should not invent missing byte-range assumptions for the
+    /// lower three limbs; those must come from surrounding AIR if they are
+    /// required for soundness.
+    fn try_emit_koala_bear_word_range_summary(
+        &mut self,
+        _input: Word<Self::Expr>,
+        _is_real: Self::Expr,
+    ) -> bool {
+        false
+    }
+
+    /// Optional hook for replacing the exact memory timestamp ordering AIR
+    /// with a compact checker-style summary.
+    ///
+    /// This hook is intentionally scoped to the arithmetic part of
+    /// `eval_memory_access_timestamp`; the surrounding memory send/receive
+    /// interactions remain the caller's responsibility. Builders that support
+    /// this hook may emit an auxiliary module with a dummy constant output when
+    /// their target IR requires every module call to produce at least one
+    /// result.
+    fn try_emit_memory_timestamp_summary(
+        &mut self,
+        _do_check: Self::Expr,
+        _shard: Self::Expr,
+        _clk: Self::Expr,
+        _prev_shard: Self::Expr,
+        _prev_clk: Self::Expr,
+        _compare_clk: Self::Expr,
+        _diff_16bit_limb: Self::Expr,
+        _diff_8bit_limb: Self::Expr,
+    ) -> bool {
+        false
+    }
+
+    /// Optional hook for replacing a large exact operation AIR with a semantic
+    /// module call that exposes only projected inputs/outputs.
+    ///
+    /// `projection_info` describes which ranges inside the hidden witness row
+    /// correspond to the caller-visible semantic boundary. Builders that
+    /// support this hook should:
+    /// - emit an auxiliary module whose interface is the flattened projected
+    ///   inputs/outputs,
+    /// - keep the rest of the witness row existential/internal, and
+    /// - use `build_exact` to populate the auxiliary module with the original
+    ///   exact constraints over a fresh hidden witness row of width
+    ///   `source_width`.
+    ///
+    /// Returning `false` leaves the caller responsible for emitting the exact
+    /// inline constraints instead.
+    fn try_emit_projected_summary<F>(
+        &mut self,
+        _module_name: &str,
+        _projection_info: &crate::air::PicusProjectionInfo,
+        _current_inputs: &[Self::Expr],
+        _current_outputs: &[Self::Expr],
+        _source_width: usize,
+        _build_exact: F,
+    ) -> bool
+    where
+        F: FnOnce(&mut Self, &[Self::Var]),
+    {
+        false
+    }
+
+    /// Optional hook for replacing an embedded exact sub-AIR with a semantic
+    /// module call whose boundary is still described by a projection.
+    ///
+    /// Unlike [`Self::try_emit_projected_summary`], this hook builds the hidden
+    /// witness as a full phase-shaped trace matrix rather than a single hidden
+    /// row. This is intended for large sub-AIRs that use `next` rows internally
+    /// but should still remain behind a compact caller-visible boundary.
+    ///
+    /// `projection_info` is interpreted on the hidden sub-AIR's local row
+    /// (row 0). Builders that support this hook should:
+    /// - emit an auxiliary module whose interface is the flattened projected
+    ///   inputs/outputs taken from that hidden local row,
+    /// - materialize a hidden trace matrix of width `source_width` and the row
+    ///   count implied by the current extraction phase plus `source_local_only`,
+    /// - run `build_exact` against that hidden trace so the full exact sub-AIR
+    ///   remains internal to the auxiliary module.
+    ///
+    /// Returning `false` leaves the caller responsible for lowering the sub-AIR
+    /// inline, typically through `SubAirBuilder`.
+    fn try_emit_hidden_subair_summary<F>(
+        &mut self,
+        _module_name: &str,
+        _projection_info: &crate::air::PicusProjectionInfo,
+        _current_inputs: &[Self::Expr],
+        _current_outputs: &[Self::Expr],
+        _source_width: usize,
+        _source_local_only: bool,
+        _build_exact: F,
+    ) -> bool
+    where
+        F: FnOnce(&mut Self),
+    {
+        false
+    }
 }
 
 /// A trait which contains methods related to ALU lookups in an AIR.

--- a/crates/stark/src/air/picus_info.rs
+++ b/crates/stark/src/air/picus_info.rs
@@ -46,3 +46,45 @@ pub struct PicusInfo {
     /// Indices of columns marked as `is_real`
     pub is_real_index: Option<usize>,
 }
+
+/// Information about a semantic projection over a larger Picus-annotated witness layout.
+///
+/// Unlike [`PicusInfo`], which describes whole storage fields in a concrete trace column
+/// struct, a projection describes only the semantically relevant slices that should appear
+/// on an operation/module boundary. This is intended for operation-level submodules where
+/// most witness columns are internal and should remain existential.
+#[derive(Debug, Clone, Default)]
+pub struct PicusProjectionInfo {
+    /// Column to projected-name mapping for every byte covered by the projection.
+    pub col_to_name: HashMap<usize, String>,
+    /// Projected field names to concrete column ranges in the source layout.
+    pub name_to_colrange: HashMap<String, (usize, usize)>,
+    /// Projected ranges that should be treated as module inputs.
+    pub input_ranges: Vec<(usize, usize, String)>,
+    /// Projected ranges that should be treated as module outputs.
+    pub output_ranges: Vec<(usize, usize, String)>,
+}
+
+/// Helper trait for projection metadata: recover the first concrete source
+/// column from either a scalar column id or a nested array of column ids.
+///
+/// Projection annotations should be able to point at the semantic slice they
+/// mean, for example `state.external_rounds_state[0]` rather than
+/// `state.external_rounds_state[0][0]`. The derive computes the projected width
+/// from the destination field type, and this trait supplies the starting source
+/// column by recursively taking the first element of nested arrays.
+pub trait PicusProjectionStart {
+    fn projection_start(&self) -> usize;
+}
+
+impl PicusProjectionStart for usize {
+    fn projection_start(&self) -> usize {
+        *self
+    }
+}
+
+impl<T: PicusProjectionStart, const N: usize> PicusProjectionStart for [T; N] {
+    fn projection_start(&self) -> usize {
+        self[0].projection_start()
+    }
+}


### PR DESCRIPTION
- added extra support to modularly extract Poseidon2 and Keccak airs
- Adding a picus-projection operation to annotate slices of an array as inputs/outputs. Useful for poseidon ops.
- Some keccak constraints were not extracted originally because they used the sub-builder. Fixing that.
