### PR TITLE
fix(keccak_sponge): hold input_address stable across rounds

### DIFF
--- a/crates/core/machine/src/syscall/precompiles/keccak_sponge/air.rs
+++ b/crates/core/machine/src/syscall/precompiles/keccak_sponge/air.rs
@@ -160,6 +160,16 @@ where
             next.input_address - AB::Expr::from_canonical_u32(KECCAK_GENERAL_RATE_U32S as u32 * 4),
         );
 
+        // Outside the absorbed-edge transition, keep `input_address` stable
+        // across rows. Exclude the final output row because its successor is a
+        // padding row.
+        let keep_input_address =
+            (AB::Expr::one() - local.is_absorbed) * (AB::Expr::one() - local.write_output);
+        builder
+            .when_transition()
+            .when(keep_input_address)
+            .assert_eq(local.input_address, next.input_address);
+
         // Outside the absorbed-edge transition, keep `original_state` stable
         // across rows. Exclude the final output row because its successor is a
         // padding row.


### PR DESCRIPTION
What was wrong

  - In `KeccakSponge` AIR, `input_address` was only constrained on the absorbed-edge transition, but it was not held stable across other non-final rounds.
    This allowed the “later absorbed-block” address arithmetic to decouple and potentially point at the wrong input region (critical soundness issue).

What changed

  - Updated `crates/core/machine/src/syscall/precompiles/keccak_sponge/air.rs` to explicitly enforce `local.input_address == next.input_address` on all transitions where we are not taking the absorbed-edge and not on the final output row, i.e. gated by `(1 - local.is_absorbed) * (1 - local.write_output)`.
  - This closes the missing stability constraint and aligns with the intended upstream fix for the `input_address` drift bug.

