### PR TITLE
feat(go-runtime): support non-byte slices

### DIFF
--- a/crates/go-runtime/zkvm_runtime/deserialize.go
+++ b/crates/go-runtime/zkvm_runtime/deserialize.go
@@ -78,18 +78,36 @@ func deserializeData(data []byte, v reflect.Value, index int) (int, error) {
 		v.SetUint(a)
 		return index + 8, nil
 	case reflect.Slice:
+		const maxSliceLen = 1_000_000
 		b := []byte{data[index], data[index+1], data[index+2], data[index+3],
 			data[index+4], data[index+5], data[index+6], data[index+7]}
 
 		length := binary.LittleEndian.Uint64(b)
 		index += 8
-		switch v.Type().Elem().Kind() {
-		case reflect.Uint8:
+		elemKind := v.Type().Elem().Kind()
+		if elemKind == reflect.Uint8 {
+			if length > uint64(len(data)-index) {
+				return index, fmt.Errorf("deserialize failed: []byte length %d exceeds remaining %d", length, len(data)-index)
+			}
 			bytes := data[index : index+int(length)]
 			v.SetBytes(bytes)
 			return index + int(length), nil
 		}
-		return index, fmt.Errorf("unsupported type: %v, elem: %v", v.Kind(), v.Elem().Kind())
+
+		if length > maxSliceLen {
+			return index, fmt.Errorf("deserialize failed: slice length %d exceeds max %d", length, maxSliceLen)
+		}
+		l := int(length)
+		slice := reflect.MakeSlice(v.Type(), l, l)
+		for i := 0; i < l; i++ {
+			var err error
+			index, err = deserializeData(data, slice.Index(i), index)
+			if err != nil {
+				return index, err
+			}
+		}
+		v.Set(slice)
+		return index, nil
 	case reflect.Array:
 		for i := 0; i < v.Len(); i++ {
 			var err error

--- a/crates/go-runtime/zkvm_runtime/serialize.go
+++ b/crates/go-runtime/zkvm_runtime/serialize.go
@@ -56,21 +56,16 @@ func serializeData(v reflect.Value) ([]byte, error) {
 		binary.LittleEndian.PutUint64(b, uint64(v.Uint()))
 		return b, nil
 	case reflect.Slice:
-		switch v.Type().Elem().Kind() {
-		case reflect.Uint8:
-			output := make([]byte, 8)
-			binary.LittleEndian.PutUint64(output, uint64(v.Len()))
-
-			for i := 0; i < v.Len(); i++ {
-				d, err := serializeData(v.Index(i))
-				if err != nil {
-					return nil, err
-				}
-				output = append(output, d...)
+		output := make([]byte, 8)
+		binary.LittleEndian.PutUint64(output, uint64(v.Len()))
+		for i := 0; i < v.Len(); i++ {
+			d, err := serializeData(v.Index(i))
+			if err != nil {
+				return nil, err
 			}
-			return output, nil
+			output = append(output, d...)
 		}
-		return nil, fmt.Errorf("unsupported type: %v, elem: %v", v.Kind(), v.Elem().Kind())
+		return output, nil
 	case reflect.Array:
 		switch v.Type().Elem().Kind() {
 		case reflect.Uint8:


### PR DESCRIPTION
Extended `crates/go-runtime/zkvm_runtime` (de)serialization to support slices of non-byte elements (e.g. `[]struct`) instead of only `[]byte`, `encoding/decoding` as u64 length followed by per-element recursive (de)serialization.