### PR TITLE
feat(go-runtime): add proof verification syscalls

### DIFF
--- a/crates/go-runtime/zkvm_runtime/runtime.go
+++ b/crates/go-runtime/zkvm_runtime/runtime.go
@@ -15,10 +15,12 @@ func SyscallWrite(fd int, write_buf []byte, nbytes int) int
 func SyscallHintLen() int
 func SyscallHintRead(ptr []byte, len int)
 func SyscallCommit(index int, word uint32)
+func SyscallCommitDeferredProofs(index int, word uint32)
 func SyscallExit(code int)
 func SyscallEnterUnconstrained() int
 func SyscallExitUnconstrained()
 func SyscallKeccakSponge(input unsafe.Pointer, result unsafe.Pointer)
+func SyscallVerifyZKMProof(vkDigest unsafe.Pointer, pvDigest unsafe.Pointer)
 
 // secp256k1 precompiles
 func SyscallSecp256k1Add(p unsafe.Pointer, q unsafe.Pointer)
@@ -81,7 +83,7 @@ func HintSlice(data []byte) {
 func ReadHintVec() []byte {
 	// Read length prefix (4 bytes LE)
 	lenLen := SyscallHintLen()
-	lenBuf := make([]byte, ((lenLen + 3) / 4) * 4)
+	lenBuf := make([]byte, ((lenLen+3)/4)*4)
 	SyscallHintRead(lenBuf, lenLen)
 	dataLen := int(lenBuf[0]) | int(lenBuf[1])<<8 | int(lenBuf[2])<<16 | int(lenBuf[3])<<24
 
@@ -94,6 +96,7 @@ func ReadHintVec() []byte {
 }
 
 var PublicValuesHasher hash.Hash = sha256.New()
+var DeferredProofsDigest [8]uint32
 
 const EMBEDDED_RESERVED_INPUT_REGION_SIZE int = 1024 * 1024 * 1024
 const MAX_MEMORY int = 0x7f000000
@@ -127,6 +130,17 @@ func Commit[T any](value T) {
 	SyscallWrite(13, bytes, length)
 }
 
+func VerifyZKMProof(vkDigest *[8]uint32, pvDigest *[32]byte) {
+	SyscallVerifyZKMProof(unsafe.Pointer(vkDigest), unsafe.Pointer(pvDigest))
+}
+
+func CommitDeferredProofsDigest(digest [8]uint32) {
+	DeferredProofsDigest = digest
+	for i, word := range digest {
+		SyscallCommitDeferredProofs(i, word)
+	}
+}
+
 //go:linkname RuntimeExit zkvm.RuntimeExit
 func RuntimeExit(code int) {
 	hashBytes := PublicValuesHasher.Sum(nil)
@@ -136,6 +150,7 @@ func RuntimeExit(code int) {
 		word := binary.LittleEndian.Uint32(hashBytes[i*4 : (i+1)*4])
 		SyscallCommit(i, word)
 	}
+	CommitDeferredProofsDigest(DeferredProofsDigest)
 
 	SyscallExit(code)
 }

--- a/crates/go-runtime/zkvm_runtime/syscall_mipsle.s
+++ b/crates/go-runtime/zkvm_runtime/syscall_mipsle.s
@@ -38,6 +38,13 @@ TEXT ·SyscallCommit(SB), $0-8
 	SYSCALL
 	RET
 
+TEXT ·SyscallCommitDeferredProofs(SB), $0-8
+	MOVW index+0(FP), R4
+	MOVW word+4(FP), R5
+	MOVW $0x1A, R2
+	SYSCALL
+	RET
+
 TEXT ·SyscallExit(SB), $0-4
 	MOVW code+0(FP), R4    // a0 = code
 	MOVW $0, R2         // v0 = syscall 0
@@ -59,6 +66,13 @@ TEXT ·SyscallKeccakSponge(SB), $0-8
 	MOVW $0x01010009, R2   // v0 = KECCAK_SPONGE syscall
 	MOVW input+0(FP), R4   // a0 = input pointer
 	MOVW result+4(FP), R5  // a1 = result pointer
+	SYSCALL
+	RET
+
+TEXT ·SyscallVerifyZKMProof(SB), $0-8
+	MOVW $0x1B, R2
+	MOVW vkDigest+0(FP), R4
+	MOVW pvDigest+4(FP), R5
 	SYSCALL
 	RET
 


### PR DESCRIPTION
I added Go zkVM runtime support for deferred proof verification.

The change introduces Go bindings and MIPS syscall stubs for:

- VERIFY_ZKM_PROOF
- COMMIT_DEFERRED_PROOFS

I also added runtime helpers to:

- verify a subproof from Go code using a subprogram vk digest and public-values digest
- commit the accumulated deferred proof digest during runtime exit

This lets Go guest programs, such as keeper-agg, participate in the same proof-carrying aggregation flow as the Rust guests.