### PR TITLE
fix(soundness): drop KoalaBear range check on Linux syscall op_b/op_c 

### DIFF
--- a/crates/core/machine/src/syscall/instructions/air.rs
+++ b/crates/core/machine/src/syscall/instructions/air.rs
@@ -162,14 +162,20 @@ impl SyscallInstrsChip {
         builder.when(AB::Expr::one() - local.is_real).assert_zero(send_to_table.clone());
 
         // KoalaBear range checks on op_b and op_c, activated by stored flags.
-        // op_b_check = 1 when send_to_table || is_halt (covers both syscall bridge and exit code).
-        // op_c_check = 1 when send_to_table || is_commit_deferred_proofs (covers bridge and digest).
+        // Only required on the precompile bridge (where args travel as a single reduced field
+        // element), for `is_halt` (exit code is reduced), and for `is_commit_deferred_proofs`
+        // (digest element is reduced). Linux syscalls travel via half-word packed columns in
+        // `SyscallChip`, which are U16-range-checked there — reduce() collision is impossible,
+        // so the KoalaBear range check is not needed (and would reject legal u32 args like
+        // AT_FDCWD = 0xFFFFFF9C).
+        let send_to_precompile: AB::Expr = get_send_table::<AB>(local).into();
+        let op_b_check_active: AB::Expr = send_to_precompile.clone() + local.is_halt.into();
+        let op_c_check_active: AB::Expr =
+            send_to_precompile + local.is_commit_deferred_proofs.result.into();
         builder.assert_bool(local.op_b_check);
         builder.assert_bool(local.op_c_check);
-        builder.when(send_to_table.clone()).assert_one(local.op_b_check);
-        builder.when(local.is_halt).assert_one(local.op_b_check);
-        builder.when(send_to_table.clone()).assert_one(local.op_c_check);
-        builder.when(local.is_commit_deferred_proofs.result).assert_one(local.op_c_check);
+        builder.when(op_b_check_active).assert_one(local.op_b_check);
+        builder.when(op_c_check_active).assert_one(local.op_c_check);
         builder.when_not(local.is_real).assert_zero(local.op_b_check);
         builder.when_not(local.is_real).assert_zero(local.op_c_check);
 

--- a/crates/core/machine/src/syscall/instructions/trace.rs
+++ b/crates/core/machine/src/syscall/instructions/trace.rs
@@ -115,7 +115,6 @@ impl SyscallInstrsChip {
         cols.is_sys_linux = F::from_bool(event.a_record.prev_value & 0x0ff00 != 0);
 
         let prev_a_bytes = event.a_record.prev_value.to_le_bytes();
-        let send_to_table = (prev_a_bytes[1] != 0) || (prev_a_bytes[2] == 1);
         let is_halt_val = cols.is_halt == F::ONE;
 
         // Populate is_prev_a1_zero for bidirectional is_sys_linux constraint.
@@ -161,10 +160,17 @@ impl SyscallInstrsChip {
         }
 
         // Populate unified KoalaBear range check flags and columns.
+        // Activate the KoalaBear range check only when the value travels as a single reduced
+        // field element: the precompile bridge (prev_a_bytes[2] == 1), `is_halt` (exit code),
+        // and `is_commit_deferred_proofs` (digest). Linux syscall args travel via half-word
+        // packed columns in `SyscallChip` (U16-range-checked), so reduce() collisions are
+        // impossible there and the KoalaBear constraint must not be applied — otherwise legal
+        // u32 args like AT_FDCWD = 0xFFFFFF9C fail the check.
+        let send_to_precompile = prev_a_bytes[2] == 1;
         let is_commit_deferred =
             syscall_id == F::from_canonical_u32(SyscallCode::COMMIT_DEFERRED_PROOFS.syscall_id());
-        let op_b_needs_check = send_to_table || is_halt_val;
-        let op_c_needs_check = send_to_table || is_commit_deferred;
+        let op_b_needs_check = send_to_precompile || is_halt_val;
+        let op_c_needs_check = send_to_precompile || is_commit_deferred;
 
         if op_b_needs_check {
             cols.op_b_check = F::ONE;

--- a/crates/go-runtime/zkvm_runtime/crypto.go
+++ b/crates/go-runtime/zkvm_runtime/crypto.go
@@ -20,16 +20,18 @@ func Sha256(data []byte) [32]byte {
 	msgLen := len(data)
 	bitLen := uint64(msgLen) * 8
 
-	// Append 0x80 byte
-	data = append(data, 0x80)
-	// Pad to 56 mod 64
-	for len(data)%64 != 56 {
-		data = append(data, 0x00)
+	// Copy into a freshly-sized buffer so we never mutate the caller's slice
+	// (callers may pass sub-slices that share a backing array with adjacent data).
+	finalBlockLen := msgLen % 64
+	paddedLen := msgLen - finalBlockLen + 64
+	if finalBlockLen >= 56 {
+		paddedLen += 64
 	}
-	// Append original length in bits as big-endian uint64
-	var lenBuf [8]byte
-	binary.BigEndian.PutUint64(lenBuf[:], bitLen)
-	data = append(data, lenBuf[:]...)
+	padded := make([]byte, paddedLen)
+	copy(padded, data)
+	padded[msgLen] = 0x80
+	binary.BigEndian.PutUint64(padded[paddedLen-8:], bitLen)
+	data = padded
 
 	// Process each 64-byte block
 	for offset := 0; offset < len(data); offset += 64 {

--- a/crates/go-runtime/zkvm_runtime/deserialize.go
+++ b/crates/go-runtime/zkvm_runtime/deserialize.go
@@ -78,18 +78,36 @@ func deserializeData(data []byte, v reflect.Value, index int) (int, error) {
 		v.SetUint(a)
 		return index + 8, nil
 	case reflect.Slice:
+		const maxSliceLen = 1_000_000
 		b := []byte{data[index], data[index+1], data[index+2], data[index+3],
 			data[index+4], data[index+5], data[index+6], data[index+7]}
 
 		length := binary.LittleEndian.Uint64(b)
 		index += 8
-		switch v.Type().Elem().Kind() {
-		case reflect.Uint8:
+		elemKind := v.Type().Elem().Kind()
+		if elemKind == reflect.Uint8 {
+			if length > uint64(len(data)-index) {
+				return index, fmt.Errorf("deserialize failed: []byte length %d exceeds remaining %d", length, len(data)-index)
+			}
 			bytes := data[index : index+int(length)]
 			v.SetBytes(bytes)
 			return index + int(length), nil
 		}
-		return index, fmt.Errorf("unsupported type: %v, elem: %v", v.Kind(), v.Elem().Kind())
+
+		if length > maxSliceLen {
+			return index, fmt.Errorf("deserialize failed: slice length %d exceeds max %d", length, maxSliceLen)
+		}
+		l := int(length)
+		slice := reflect.MakeSlice(v.Type(), l, l)
+		for i := 0; i < l; i++ {
+			var err error
+			index, err = deserializeData(data, slice.Index(i), index)
+			if err != nil {
+				return index, err
+			}
+		}
+		v.Set(slice)
+		return index, nil
 	case reflect.Array:
 		for i := 0; i < v.Len(); i++ {
 			var err error

--- a/crates/go-runtime/zkvm_runtime/runtime.go
+++ b/crates/go-runtime/zkvm_runtime/runtime.go
@@ -15,10 +15,12 @@ func SyscallWrite(fd int, write_buf []byte, nbytes int) int
 func SyscallHintLen() int
 func SyscallHintRead(ptr []byte, len int)
 func SyscallCommit(index int, word uint32)
+func SyscallCommitDeferredProofs(index int, word uint32)
 func SyscallExit(code int)
 func SyscallEnterUnconstrained() int
 func SyscallExitUnconstrained()
 func SyscallKeccakSponge(input unsafe.Pointer, result unsafe.Pointer)
+func SyscallVerifyZKMProof(vkDigest unsafe.Pointer, pvDigest unsafe.Pointer)
 
 // secp256k1 precompiles
 func SyscallSecp256k1Add(p unsafe.Pointer, q unsafe.Pointer)
@@ -81,7 +83,7 @@ func HintSlice(data []byte) {
 func ReadHintVec() []byte {
 	// Read length prefix (4 bytes LE)
 	lenLen := SyscallHintLen()
-	lenBuf := make([]byte, ((lenLen + 3) / 4) * 4)
+	lenBuf := make([]byte, ((lenLen+3)/4)*4)
 	SyscallHintRead(lenBuf, lenLen)
 	dataLen := int(lenBuf[0]) | int(lenBuf[1])<<8 | int(lenBuf[2])<<16 | int(lenBuf[3])<<24
 
@@ -94,6 +96,7 @@ func ReadHintVec() []byte {
 }
 
 var PublicValuesHasher hash.Hash = sha256.New()
+var DeferredProofsDigest [8]uint32
 
 const EMBEDDED_RESERVED_INPUT_REGION_SIZE int = 1024 * 1024 * 1024
 const MAX_MEMORY int = 0x7f000000
@@ -127,6 +130,17 @@ func Commit[T any](value T) {
 	SyscallWrite(13, bytes, length)
 }
 
+func VerifyZKMProof(vkDigest *[8]uint32, pvDigest *[32]byte) {
+	SyscallVerifyZKMProof(unsafe.Pointer(vkDigest), unsafe.Pointer(pvDigest))
+}
+
+func CommitDeferredProofsDigest(digest [8]uint32) {
+	DeferredProofsDigest = digest
+	for i, word := range digest {
+		SyscallCommitDeferredProofs(i, word)
+	}
+}
+
 //go:linkname RuntimeExit zkvm.RuntimeExit
 func RuntimeExit(code int) {
 	hashBytes := PublicValuesHasher.Sum(nil)
@@ -136,6 +150,7 @@ func RuntimeExit(code int) {
 		word := binary.LittleEndian.Uint32(hashBytes[i*4 : (i+1)*4])
 		SyscallCommit(i, word)
 	}
+	CommitDeferredProofsDigest(DeferredProofsDigest)
 
 	SyscallExit(code)
 }

--- a/crates/go-runtime/zkvm_runtime/serialize.go
+++ b/crates/go-runtime/zkvm_runtime/serialize.go
@@ -56,21 +56,16 @@ func serializeData(v reflect.Value) ([]byte, error) {
 		binary.LittleEndian.PutUint64(b, uint64(v.Uint()))
 		return b, nil
 	case reflect.Slice:
-		switch v.Type().Elem().Kind() {
-		case reflect.Uint8:
-			output := make([]byte, 8)
-			binary.LittleEndian.PutUint64(output, uint64(v.Len()))
-
-			for i := 0; i < v.Len(); i++ {
-				d, err := serializeData(v.Index(i))
-				if err != nil {
-					return nil, err
-				}
-				output = append(output, d...)
+		output := make([]byte, 8)
+		binary.LittleEndian.PutUint64(output, uint64(v.Len()))
+		for i := 0; i < v.Len(); i++ {
+			d, err := serializeData(v.Index(i))
+			if err != nil {
+				return nil, err
 			}
-			return output, nil
+			output = append(output, d...)
 		}
-		return nil, fmt.Errorf("unsupported type: %v, elem: %v", v.Kind(), v.Elem().Kind())
+		return output, nil
 	case reflect.Array:
 		switch v.Type().Elem().Kind() {
 		case reflect.Uint8:

--- a/crates/go-runtime/zkvm_runtime/syscall_mipsle.s
+++ b/crates/go-runtime/zkvm_runtime/syscall_mipsle.s
@@ -38,6 +38,13 @@ TEXT ·SyscallCommit(SB), $0-8
 	SYSCALL
 	RET
 
+TEXT ·SyscallCommitDeferredProofs(SB), $0-8
+	MOVW index+0(FP), R4
+	MOVW word+4(FP), R5
+	MOVW $0x1A, R2
+	SYSCALL
+	RET
+
 TEXT ·SyscallExit(SB), $0-4
 	MOVW code+0(FP), R4    // a0 = code
 	MOVW $0, R2         // v0 = syscall 0
@@ -59,6 +66,13 @@ TEXT ·SyscallKeccakSponge(SB), $0-8
 	MOVW $0x01010009, R2   // v0 = KECCAK_SPONGE syscall
 	MOVW input+0(FP), R4   // a0 = input pointer
 	MOVW result+4(FP), R5  // a1 = result pointer
+	SYSCALL
+	RET
+
+TEXT ·SyscallVerifyZKMProof(SB), $0-8
+	MOVW $0x1B, R2
+	MOVW vkDigest+0(FP), R4
+	MOVW pvDigest+4(FP), R5
 	SYSCALL
 	RET
 


### PR DESCRIPTION
- [b42115a](https://github.com/ProjectZKM/Ziren/pull/514/commits/b42115a5a0d6611d955f408196176ffdfcf0cbfb)
    - Symptom. Constraint failure `1 != 0` in `KoalaBearWordRangeChecker::range_check` inside `SyscallInstrsChip::eval`, at row 276 of the `SyscallInstrs` chip. The failing row was a Linux `SYS_OPENAT` (4288) invocation whose first argument was `AT_FDCWD = -100 = 0xFFFFFF9C`. The most-significant byte (0xFF) has bit 7 set, so the value exceeds the KoalaBear modulus (~2^31) and cannot pass the range check.
    - Root cause. In `crates/core/machine/src/syscall/instructions/air.rs`, the activation condition for the `KoalaBear` range checks on `op_b_value / op_c_value` was:
        
        ```bash
        op_b_check active when (is_sys_linux + get_send_table) == 1 || is_halt
        op_c_check active when (is_sys_linux + get_send_table) == 1 || is_commit_deferred_proofs
        ```
        
        The is_sys_linux term forced every Linux syscall to range-check its register args into the KoalaBear field. But Linux syscall arguments are arbitrary 32-bit register values (negative fds, stack pointers, addresses, etc.) and routinely exceed the field modulus.
        
    - Why Linux doesn't need the check. `SyscallInstrsChip` emits a second lookup, `send_syscall_result`, that passes the full `op_b_value / op_c_value` byte-words to `SyscallChip`. `SyscallChip` stores them as U16-range-checked half-words (arg1_lo, arg1_hi, …) and forwards them via `send_syscall_result_packed`. This direct byte-word linkage pins the half-words to the original bytes, so a reduce() collision on the `send_syscall` field-element bridge cannot let a malicious prover swap in a different (`arg_lo`, `arg_hi`) pair. The `KoalaBear` range check is therefore redundant for Linux.
    - Precompile syscalls (where only the reduced `send_syscall` bridge connects the CPU to the precompile chip), `is_halt` (`op_b` is compared as a field element against `public_values.exit_code`), and `is_commit_deferred_proofs` (`op_c` is compared as a field element against `deferred_proofs_digest`) still need the range check, because in each of those paths the value travels as a single reduced field element with no half-word backstop.


- [098ca28](https://github.com/ProjectZKM/Ziren/pull/514/commits/098ca280c15e16e11eec2514b6856b24f4b79bf8)
Sha256 grew the input via `append` to add SHA-256 padding, which silently mutates the backing array when the caller passes a sub-slice with spare capacity. Combined with DeserializeData returning zero-copy sub-slices for `[]byte` fields, hashing element i of a `[][]byte` clobbered element i+1 — so the agg program would verify proof 0 fine and fail proof 1 with a `committed_value_digest` mismatch. Build the padded buffer separately and leave the input untouched.
