### PR TITLE
fix(keccak): constrain keccak sponge initial state

### DIFF
--- a/crates/core/machine/src/syscall/precompiles/keccak_sponge/air.rs
+++ b/crates/core/machine/src/syscall/precompiles/keccak_sponge/air.rs
@@ -142,6 +142,12 @@ where
             .assert_eq(local.input_address, next.input_address);
         // If this is the first block, absorbed bytes should be 0
         builder.when(first_block).assert_eq(local.already_absorbed_u32s, AB::Expr::zero());
+        // If this is the first block, the sponge state must start from the
+        // fixed all-zero Keccak IV.
+        let mut first_block_builder = builder.when(first_block);
+        for i in 0..KECCAK_STATE_U32S {
+            first_block_builder.assert_word_zero(local.original_state[i]);
+        }
         // If this is the final block, absorbed bytes should be equal to the input length - KECCAK_GENERAL_RATE_U32S
         builder.when(final_block).assert_eq(
             local.already_absorbed_u32s,


### PR DESCRIPTION
# Issue 008 

First-block initial sponge state not constrained to zero (absorbed input fully malleable).

The KeccakSponge chip never constrains the initial sponge state (original_state, 50 u32 words) to zero on the first absorbed block. The only first-block boundary constraint zeroes already_absorbed_u32s, not the state itself. Because the rate is absorbed as xored_general_rate = original_state XOR block_mem and the capacity input is bound directly to original_state, a malicious prover who leaves original_state free can make the entire 1600-bit permutation input arbitrary and independent of the data actually read from memory.

For a single-block keccak call this is a total break of the hash's input→output binding: the prover can prove keccak_sponge(buffer) = keccak-f(P) for any preimage P unrelated to buffer. Concretely, the rate words feed block_mem XOR original_state_rate; with original_state_rate free the absorbed rate is block_mem XOR mask for prover-chosen mask (decoupled from the genuinely memory-read block), and the capacity words are taken directly from the free original_state. The block_mem reads are still memory-consistency-checked, but the XOR with a free operand erases that binding.

This is distinct from the existing keccak findings: ZR-180/ZR-190 concern non-canonical byte splits (value-invariant, assessed false-positive on deep review), and ZR-192 concerns the input address not propagating across blocks. None of them constrains the initial state word value.

# Fix

Fixed by adding a first-block AIR constraint that forces the full Keccak sponge original_state to zero.

  Specifically, in keccak_sponge/air.rs, next to the existing first-block constraint for already_absorbed_u32s, the code now
  iterates over all KECCAK_STATE_U32S words and calls:

  `first_block_builder.assert_word_zero(local.original_state[i]);`

  This anchors the first absorbed block to Keccak’s required all-zero IV. As a result, the rate input is again bound to the memory-
  read block, and the capacity words can no longer be chosen freely by a malicious prover.
