### PR TITLE
fix(boolean-garble): require first gate

### DIFF
--- a/crates/core/machine/src/syscall/precompiles/boolean_circuit_garble/air.rs
+++ b/crates/core/machine/src/syscall/precompiles/boolean_circuit_garble/air.rs
@@ -250,6 +250,7 @@ impl BooleanCircuitGarbleChip {
         builder.when(local.is_first_row).assert_eq(next.clk, local.clk);
         builder.when(local.is_first_row).assert_eq(next.gates_num, local.gates_num);
         builder.when(local.is_first_row).assert_zero(next.is_first_row);
+        builder.when(local.is_first_row).assert_one(next.is_first_gate);
         builder.when(local.is_first_row).assert_eq(next.is_gate, next.is_first_gate);
         builder.when(local.is_first_row).assert_eq(next.checks_acc, next.is_gate);
         // Continue with next gate row only when explicitly in same-event continuation.


### PR DESCRIPTION
# Issue 034

No constraint enforces that an is_first_row row must be followed by an is_first_gate row. A prover could construct traces with multiple consecutive header rows, gates without headers, or header rows followed by padding.

# Fix

Add the missing prelude-to-first-gate transition constraint:

```
builder.when(local.is_first_row).assert_one(next.is_first_gate);
```

This closes the gap where a header row could be followed by padding or a non-first gate. Since the AIR already enforces
is_first_gate => gate_id == 0 and next.is_gate == next.is_first_gate in this bridge, the next row is now forced to be the real
first gate row.