### PR TITLE
fix: correct Poseidon2 KoalaBear partial rounds to 20 (security parameter)

### DIFF
--- a/crates/core/machine/src/operations/poseidon2/mod.rs
+++ b/crates/core/machine/src/operations/poseidon2/mod.rs
@@ -15,7 +15,7 @@ pub const RATE: usize = WIDTH / 2;
 pub const NUM_EXTERNAL_ROUNDS: usize = 8;
 
 /// The number of internal rounds.
-pub const NUM_INTERNAL_ROUNDS: usize = 13;
+pub const NUM_INTERNAL_ROUNDS: usize = 20;
 
 /// The total number of rounds.
 pub const NUM_ROUNDS: usize = NUM_EXTERNAL_ROUNDS + NUM_INTERNAL_ROUNDS;

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -1106,7 +1106,7 @@ lazy_static! {
 
 pub fn poseidon2_init() -> Poseidon2KoalaBear<16> {
     const ROUNDS_F: usize = 8;
-    const ROUNDS_P: usize = 13;
+    const ROUNDS_P: usize = 20;
     let mut round_constants = RC_16_30.to_vec();
     let internal_start = ROUNDS_F / 2;
     let internal_end = (ROUNDS_F / 2) + ROUNDS_P;

--- a/crates/recursion/core/src/chips/poseidon2_skinny/mod.rs
+++ b/crates/recursion/core/src/chips/poseidon2_skinny/mod.rs
@@ -13,7 +13,7 @@ pub const WIDTH: usize = 16;
 pub const RATE: usize = WIDTH / 2;
 
 pub const NUM_EXTERNAL_ROUNDS: usize = 8;
-pub const NUM_INTERNAL_ROUNDS: usize = 13;
+pub const NUM_INTERNAL_ROUNDS: usize = 20;
 pub const NUM_ROUNDS: usize = NUM_EXTERNAL_ROUNDS + NUM_INTERNAL_ROUNDS;
 
 /// A chip that implements the Poseidon2 permutation in the skinny variant (one external round per

--- a/crates/recursion/core/src/chips/poseidon2_wide/mod.rs
+++ b/crates/recursion/core/src/chips/poseidon2_wide/mod.rs
@@ -19,7 +19,7 @@ pub const WIDTH: usize = 16;
 pub const RATE: usize = WIDTH / 2;
 
 pub const NUM_EXTERNAL_ROUNDS: usize = 8;
-pub const NUM_INTERNAL_ROUNDS: usize = 13;
+pub const NUM_INTERNAL_ROUNDS: usize = 20;
 pub const NUM_ROUNDS: usize = NUM_EXTERNAL_ROUNDS + NUM_INTERNAL_ROUNDS;
 
 /// A chip that implements addition for the opcode Poseidon2Wide.

--- a/crates/stark/src/kb31_poseidon2.rs
+++ b/crates/stark/src/kb31_poseidon2.rs
@@ -183,7 +183,7 @@ pub mod koala_bear_poseidon2 {
     #[must_use]
     pub fn my_perm() -> Perm {
         const ROUNDS_F: usize = 8;
-        const ROUNDS_P: usize = 13;
+        const ROUNDS_P: usize = 20;
         let mut round_constants = RC_16_30.to_vec();
         let internal_start = ROUNDS_F / 2;
         let internal_end = (ROUNDS_F / 2) + ROUNDS_P;


### PR DESCRIPTION
## Summary
Changes `ROUNDS_P`/`NUM_INTERNAL_ROUNDS` from **13 → 20** across all 4 Poseidon2 layers.

## Why
Per both upstream Plonky3 and the project's own fork (ProjectZKM/Plonky3), the correct partial rounds for KoalaBear (31-bit, width 16, alpha=3) is **20**, not 13.

Reference: `poseidon2/src/round_numbers.rs:40`:
```
31 => match (width, d) {
    (16, 3) => (8, 20),
```

The project already provides 30 round constants (`RC_16_30`) which implies the config was always intended for 8+20=28 rounds (plus 2 buffer).

## Files changed
- `crates/primitives/src/lib.rs` — `ROUNDS_P` in `poseidon2_init()`
- `crates/core/machine/src/operations/poseidon2/mod.rs` — kernel prover
- `crates/recursion/core/src/chips/poseidon2_skinny/mod.rs` — recursion skinny
- `crates/recursion/core/src/chips/poseidon2_wide/mod.rs` — recursion wide
- `crates/stark/src/kb31_poseidon2.rs` — test reference (was self-referentially wrong)

Fixes #524