### PR TITLE
ci: limit test-threads to 8 in time-consuming workflow

### DIFF
--- a/.github/workflows/ci_time_consuming.yml
+++ b/.github/workflows/ci_time_consuming.yml
@@ -17,8 +17,8 @@ jobs:
       - run: export PATH=~/.cargo/bin:$PATH
       - run: |
           source ~/.zkm-toolchain/env
-          cargo test -r -p zkm-core-machine
+          cargo test -r -p zkm-core-machine -- --test-threads=8
           for pkg in zkm-sdk zkm-verifier; do
-            RUSTFLAGS="-C target-cpu=native" cargo test -r -p $pkg
+            RUSTFLAGS="-C target-cpu=native" cargo test -r -p $pkg -- --test-threads=8
           done
-          RUSTFLAGS="-C target-cpu=native" cargo test -r --features imm-wrap-vk --features ark -- --ignored test_verify_groth16_imm_wrap_vk
+          RUSTFLAGS="-C target-cpu=native" cargo test -r --features imm-wrap-vk --features ark -- --ignored --test-threads=8 test_verify_groth16_imm_wrap_vk


### PR DESCRIPTION
Timeline analysis of the logs shows the failure lands exactly when the run reaches its peak of 16 concurrently executing tests (cargo defaults to nproc, and the runner has 16 cores). The last green run (v1.2.7, 2026-07-13) hit the same 16-way peak at the same point in the schedule and went on to finish the block in 2832s, so the workload profile is unchanged; what changed is the memory available on the self-hosted runner. SIGTERM rather than SIGKILL points at an out-of-memory daemon such as earlyoom, which picks the largest-RSS process — and all 120 proving tests share a single test binary, so their memory sums into one target.

Capping at 8 threads halves peak memory. Applied to all three cargo test invocations in this workflow since they run on the same host. Expect the job to take noticeably longer.
